### PR TITLE
do not impose send + sync for schedule function for spawn_local

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -90,7 +90,7 @@ impl<F, R, S, T> Clone for RawTask<F, R, S, T> {
 impl<F, R, S, T> RawTask<F, R, S, T>
 where
     F: Future<Output = R> + 'static,
-    S: Fn(Task<T>) + Send + Sync + 'static,
+    S: Fn(Task<T>) + 'static,
 {
     const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
         Self::clone_waker,
@@ -612,12 +612,12 @@ where
         struct Guard<F, R, S, T>(RawTask<F, R, S, T>)
         where
             F: Future<Output = R> + 'static,
-            S: Fn(Task<T>) + Send + Sync + 'static;
+            S: Fn(Task<T>) + 'static;
 
         impl<F, R, S, T> Drop for Guard<F, R, S, T>
         where
             F: Future<Output = R> + 'static,
-            S: Fn(Task<T>) + Send + Sync + 'static,
+            S: Fn(Task<T>) + 'static,
         {
             fn drop(&mut self) {
                 let raw = self.0;

--- a/src/task.rs
+++ b/src/task.rs
@@ -117,8 +117,8 @@ pub fn spawn_local<F, R, S, T>(future: F, schedule: S, tag: T) -> (Task<T>, Join
 where
     F: Future<Output = R> + 'static,
     R: 'static,
-    S: Fn(Task<T>) + Send + Sync + 'static,
-    T: Send + Sync + 'static,
+    S: Fn(Task<T>) + 'static,
+    T: 'static,
 {
     extern crate std;
 


### PR DESCRIPTION
There is a version of spawn, called spawn_local, that does not require
the future to implement Send + Sync. That makes sense, since those
futures are supposed to be used in the same thread in which they were
created.

However, the Send + Sync requirement is still imposed in the schedule
function that accompanies the future implementation. This causes the
future implementation itself to resort to expensive atomic operations
where simple reference counts would do.

To achieve this, I propose the Send+Sync requirement to be removed
from the RawTask, which is an internal abstraction invisible to the
user of this crate.

The Send + Sync requirement on the schedule function will still be
upheld for the function passed to spawn.