### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/async-task"
 description = "Task abstraction for building executors"
 keywords = ["futures", "task", "executor", "spawn"]
 categories = ["asynchronous", "concurrency", "no-std"]
-readme = "README.md"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.