### PR TITLE
Add non-panicking poll option for Task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ flaky_test = "0.1"
 flume = { version = "0.10", default-features = false }
 once_cell = "1"
 smol = "1"
+
+# rewrite dependencies to use the this version of async-task when running tests
+[patch.crates-io]
+async-task = { path = "." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ mod task;
 mod utils;
 
 pub use crate::runnable::{spawn, spawn_unchecked, Runnable};
-pub use crate::task::Task;
+pub use crate::task::{FallibleTask, Task};
 
 #[cfg(feature = "std")]
 pub use crate::runnable::spawn_local;


### PR DESCRIPTION
Introduces a new wrapper `FallibleTask<T>` type which allows awaiting a task's completion without panicking if the task was cancelled due to its `Runnable` being dropped without being run.

Fixes #20 