### PR TITLE
Let the compiler do memory layout computation for tasks at compile time

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use core::alloc::Layout;
 use core::mem;
 
 /// Aborts the process.
@@ -34,31 +33,4 @@ pub(crate) fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
     let t = f();
     mem::forget(bomb);
     t
-}
-
-/// Returns the layout for `a` followed by `b` and the offset of `b`.
-///
-/// This function was adapted from the currently unstable `Layout::extend()`:
-/// https://doc.rust-lang.org/nightly/std/alloc/struct.Layout.html#method.extend
-#[inline]
-pub(crate) fn extend(a: Layout, b: Layout) -> (Layout, usize) {
-    let new_align = a.align().max(b.align());
-    let pad = padding_needed_for(a, b.align());
-
-    let offset = a.size().checked_add(pad).unwrap();
-    let new_size = offset.checked_add(b.size()).unwrap();
-
-    let layout = Layout::from_size_align(new_size, new_align).unwrap();
-    (layout, offset)
-}
-
-/// Returns the padding after `layout` that aligns the following address to `align`.
-///
-/// This function was adapted from the currently unstable `Layout::padding_needed_for()`:
-/// https://doc.rust-lang.org/nightly/std/alloc/struct.Layout.html#method.padding_needed_for
-#[inline]
-pub(crate) fn padding_needed_for(layout: Layout, align: usize) -> usize {
-    let len = layout.size();
-    let len_rounded_up = len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
-    len_rounded_up.wrapping_sub(len)
 }


### PR DESCRIPTION
Let the compiler do memory layout computation for tasks at compile time instead of doing them manually at runtime.

Also note that it is advantageous for (crash dump) debugging to have an actual type that defines the layout, because that type will be described in debuginfo, which in turn allows debuggers to decode a task's raw memory blob. Without that type definiton, we cannot compute task layouts at runtime because debuginfo does not contain information about type alignments on all platforms.

Being able to decode raw task memory in debuggers is a prerequisite for eventually implementing [logical stack traces](https://internals.rust-lang.org/t/async-debugging-logical-stack-traces-setting-goals-collecting-examples/15547).