### PR TITLE
Add metadata to tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ mod state;
 mod task;
 mod utils;
 
-pub use crate::runnable::{spawn, spawn_unchecked, Runnable};
+pub use crate::runnable::{spawn, spawn_unchecked, Builder, Runnable};
 pub use crate::task::{FallibleTask, Task};
 
 #[cfg(feature = "std")]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -65,7 +65,7 @@ pub(crate) struct TaskLayout {
 }
 
 /// Raw pointers to the fields inside a task.
-pub(crate) struct RawTask<F, G, T, S, M> {
+pub(crate) struct RawTask<F, T, S, M> {
     /// The task header.
     pub(crate) header: *const Header<M>,
 
@@ -73,39 +73,21 @@ pub(crate) struct RawTask<F, G, T, S, M> {
     pub(crate) schedule: *const S,
 
     /// The future.
-    pub(crate) future: *mut FutureOrGen<F, G, M>,
+    pub(crate) future: *mut F,
 
     /// The output of the future.
     pub(crate) output: *mut T,
 }
 
-impl<F, G, T, S, M> Copy for RawTask<F, G, T, S, M> {}
+impl<F, T, S, M> Copy for RawTask<F, T, S, M> {}
 
-impl<F, G, T, S, M> Clone for RawTask<F, G, T, S, M> {
+impl<F, T, S, M> Clone for RawTask<F, T, S, M> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-/// Either a future or a function that can be used to generate that future.
-pub(crate) enum FutureOrGen<F, G, M> {
-    /// The future.
-    ///
-    /// The future is logically pinned whenever this object is pinned. It
-    /// should not be moved.
-    Future(F),
-
-    /// The generator function.
-    ///
-    /// The generator function is never logically pinned. It can be moved
-    /// around freely.
-    Gen(G),
-
-    /// Empty slot.
-    Empty(PhantomData<M>),
-}
-
-impl<F, G, T, S, M> RawTask<F, G, T, S, M> {
+impl<F, T, S, M> RawTask<F, T, S, M> {
     const TASK_LAYOUT: Option<TaskLayout> = Self::eval_task_layout();
 
     /// Computes the memory layout for a task.
@@ -114,7 +96,7 @@ impl<F, G, T, S, M> RawTask<F, G, T, S, M> {
         // Compute the layouts for `Header`, `S`, `F`, and `T`.
         let layout_header = Layout::new::<Header<M>>();
         let layout_s = Layout::new::<S>();
-        let layout_f = Layout::new::<FutureOrGen<F, G, M>>();
+        let layout_f = Layout::new::<F>();
         let layout_r = Layout::new::<T>();
 
         // Compute the layout for `union { F, T }`.
@@ -138,12 +120,10 @@ impl<F, G, T, S, M> RawTask<F, G, T, S, M> {
     }
 }
 
-impl<'a, F, G, T, S, M> RawTask<F, G, T, S, M>
+impl<F, T, S, M> RawTask<F, T, S, M>
 where
-    F: Future<Output = T> + 'a,
-    G: FnOnce(&'a M) -> F,
+    F: Future<Output = T>,
     S: Fn(Runnable<M>),
-    M: 'a,
 {
     const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
         Self::clone_waker,
@@ -155,7 +135,15 @@ where
     /// Allocates a task with the given `future` and `schedule` function.
     ///
     /// It is assumed that initially only the `Runnable` and the `Task` exist.
-    pub(crate) fn allocate(future: FutureOrGen<F, G, M>, schedule: S, metadata: M) -> NonNull<()> {
+    pub(crate) fn allocate<'a, Gen: FnOnce(&'a M) -> F>(
+        future: Gen,
+        schedule: S,
+        metadata: M,
+    ) -> NonNull<()>
+    where
+        F: 'a,
+        M: 'a,
+    {
         // Compute the layout of the task for allocation. Abort if the computation fails.
         //
         // n.b. notgull: task_layout now automatically aborts instead of panicking
@@ -190,6 +178,9 @@ where
             // Write the schedule function as the third field of the task.
             (raw.schedule as *mut S).write(schedule);
 
+            // Generate the future, now that the metadata has been pinned in place.
+            let future = abort_on_panic(|| future(&(*raw.header).metadata));
+
             // Write the future as the fourth field of the task.
             raw.future.write(future);
 
@@ -207,7 +198,7 @@ where
             Self {
                 header: p as *const Header<M>,
                 schedule: p.add(task_layout.offset_s) as *const S,
-                future: p.add(task_layout.offset_f) as *mut FutureOrGen<F, G, M>,
+                future: p.add(task_layout.offset_f) as *mut F,
                 output: p.add(task_layout.offset_r) as *mut T,
             }
         }
@@ -534,8 +525,8 @@ where
 
         // Poll the inner future, but surround it with a guard that closes the task in case polling
         // panics.
-        let guard = Guard::<'a, _, _, _, _, _>(raw, &());
-        let poll = Pin::new_unchecked(&mut *raw.future).poll(cx, &(*raw.header).metadata);
+        let guard = Guard(raw);
+        let poll = <F as Future>::poll(Pin::new_unchecked(&mut *raw.future), cx);
         mem::forget(guard);
 
         match poll {
@@ -652,19 +643,15 @@ where
         return false;
 
         /// A guard that closes the task if polling its future panics.
-        struct Guard<'a, F, G, T, S, M>(RawTask<F, G, T, S, M>, &'a ())
-        where
-            F: Future<Output = T> + 'a,
-            G: FnOnce(&'a M) -> F,
-            S: Fn(Runnable<M>),
-            M: 'a;
-
-        impl<'a, F, G, T, S, M> Drop for Guard<'a, F, G, T, S, M>
+        struct Guard<F, T, S, M>(RawTask<F, T, S, M>)
         where
             F: Future<Output = T>,
-            G: FnOnce(&'a M) -> F,
+            S: Fn(Runnable<M>);
+
+        impl<F, T, S, M> Drop for Guard<F, T, S, M>
+        where
+            F: Future<Output = T>,
             S: Fn(Runnable<M>),
-            M: 'a,
         {
             fn drop(&mut self) {
                 let raw = self.0;
@@ -679,7 +666,7 @@ where
                         if state & CLOSED != 0 {
                             // The thread that closed the task didn't drop the future because it
                             // was running so now it's our responsibility to do so.
-                            RawTask::<F, G, T, S, M>::drop_future(ptr);
+                            RawTask::<F, T, S, M>::drop_future(ptr);
 
                             // Mark the task as not running and not scheduled.
                             (*raw.header)
@@ -693,7 +680,7 @@ where
                             }
 
                             // Drop the task reference.
-                            RawTask::<F, G, T, S, M>::drop_ref(ptr);
+                            RawTask::<F, T, S, M>::drop_ref(ptr);
 
                             // Notify the awaiter that the future has been dropped.
                             if let Some(w) = awaiter {
@@ -711,7 +698,7 @@ where
                         ) {
                             Ok(state) => {
                                 // Drop the future because the task is now closed.
-                                RawTask::<F, G, T, S, M>::drop_future(ptr);
+                                RawTask::<F, T, S, M>::drop_future(ptr);
 
                                 // Take the awaiter out.
                                 let mut awaiter = None;
@@ -720,7 +707,7 @@ where
                                 }
 
                                 // Drop the task reference.
-                                RawTask::<F, G, T, S, M>::drop_ref(ptr);
+                                RawTask::<F, T, S, M>::drop_ref(ptr);
 
                                 // Notify the awaiter that the future has been dropped.
                                 if let Some(w) = awaiter {
@@ -731,42 +718,6 @@ where
                             Err(s) => state = s,
                         }
                     }
-                }
-            }
-        }
-    }
-}
-
-impl<'a, M: 'a, Fut: Future + 'a, Gen: FnOnce(&'a M) -> Fut> FutureOrGen<Fut, Gen, M> {
-    /// Polls the future or runs the generator and then polls the future.
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>, meta: &'a M) -> Poll<Fut::Output> {
-        // SAFETY: We do manual pin projection here.
-        //
-        // - We never use the "fut" reference without pinning it first.
-        // - "Gen" is never logically pinned, so it's okay to move it.
-        unsafe {
-            loop {
-                match self.as_mut().get_unchecked_mut() {
-                    FutureOrGen::Future(fut) => return Pin::new_unchecked(fut).poll(cx),
-
-                    FutureOrGen::Gen(_) => {
-                        // Extract the generator.
-                        let gen = match mem::replace(
-                            self.as_mut().get_unchecked_mut(),
-                            FutureOrGen::Empty(PhantomData),
-                        ) {
-                            FutureOrGen::Gen(gen) => gen,
-                            _ => unreachable!(),
-                        };
-
-                        // Call the generator, making sure to abort if it panics.
-                        let fut = abort_on_panic(move || gen(meta));
-
-                        // Replace the generator with the future.
-                        self.set(FutureOrGen::Future(fut));
-                    }
-
-                    _ => unreachable!("cannot poll an empty hole"),
                 }
             }
         }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -446,6 +446,9 @@ where
 
         // We need a safeguard against panics because destructors can panic.
         abort_on_panic(|| {
+            // Drop the header along with the metadata.
+            (raw.header as *mut Header<M>).drop_in_place();
+
             // Drop the schedule function.
             (raw.schedule as *mut S).drop_in_place();
         });

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -6,6 +6,8 @@ use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use core::task::Waker;
 
+use alloc::boxed::Box;
+
 use crate::header::Header;
 use crate::raw::{FutureOrGen, RawTask};
 use crate::state::*;
@@ -317,7 +319,7 @@ impl<M> Builder<M> {
         let ptr = if mem::size_of::<Fut>() >= 2048 || mem::size_of::<F>() >= 2048 {
             let future = Box::new(|meta| {
                 let future = future(meta);
-                alloc::boxed::Box::pin(future)
+                Box::pin(future)
             });
 
             RawTask::<_, _, Fut::Output, S, M>::allocate(

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -11,6 +11,315 @@ use crate::raw::RawTask;
 use crate::state::*;
 use crate::Task;
 
+/// A builder that creates a new task.
+#[derive(Debug)]
+pub struct Builder<M> {
+    /// The metadata associated with the task.
+    metadata: M,
+}
+
+impl<M: Default> Default for Builder<M> {
+    fn default() -> Self {
+        Builder::new().metadata(M::default())
+    }
+}
+
+impl Builder<()> {
+    /// Creates a new task builder.
+    ///
+    /// By default, this task builder has no metadata. Use the [`metadata`] method to
+    /// set the metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_task::Builder;
+    ///
+    /// let (runnable, task) = Builder::new().spawn(async {}, |_| {});
+    /// ```
+    pub fn new() -> Builder<()> {
+        Builder { metadata: () }
+    }
+
+    /// Adds metadata to the task.
+    ///
+    /// In certain cases, it may be useful to associate some metadata with a task. For instance,
+    /// you may want to associate a name with a task, or a priority for a priority queue. This
+    /// method allows the user to attach arbitrary metadata to a task that is available through
+    /// the [`Runnable`] or the [`Task`].
+    ///
+    /// # Examples
+    ///
+    /// This example creates an executor that associates a "priority" number with each task, and
+    /// then runs the tasks in order of priority.
+    ///
+    /// ```
+    /// use async_task::{Builder, Runnable};
+    /// use once_cell::sync::Lazy;
+    /// use std::cmp;
+    /// use std::collections::BinaryHeap;
+    /// use std::sync::Mutex;
+    ///
+    /// # smol::future::block_on(async {
+    /// /// A wrapper around a `Runnable<usize>` that implements `Ord` so that it can be used in a
+    /// /// priority queue.
+    /// struct TaskWrapper(Runnable<usize>);
+    ///
+    /// impl PartialEq for TaskWrapper {
+    ///     fn eq(&self, other: &Self) -> bool {
+    ///         self.0.metadata() == other.0.metadata()
+    ///     }
+    /// }
+    ///
+    /// impl Eq for TaskWrapper {}
+    ///
+    /// impl PartialOrd for TaskWrapper {
+    ///    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+    ///       Some(self.cmp(other))
+    ///    }
+    /// }
+    ///
+    /// impl Ord for TaskWrapper {
+    ///    fn cmp(&self, other: &Self) -> cmp::Ordering {
+    ///        self.0.metadata().cmp(other.0.metadata())
+    ///    }
+    /// }
+    ///
+    /// static EXECUTOR: Lazy<Mutex<BinaryHeap<TaskWrapper>>> = Lazy::new(|| {
+    ///     Mutex::new(BinaryHeap::new())
+    /// });
+    ///
+    /// let schedule = |runnable| {
+    ///     EXECUTOR.lock().unwrap().push(TaskWrapper(runnable));
+    /// };
+    ///
+    /// // Spawn a few tasks with different priorities.
+    /// let spawn_task = move |priority| {
+    ///     let (runnable, task) = Builder::new().metadata(priority).spawn(
+    ///         async move { priority },
+    ///         schedule,
+    ///     );
+    ///     runnable.schedule();
+    ///     task
+    /// };
+    ///
+    /// let t1 = spawn_task(1);
+    /// let t2 = spawn_task(2);
+    /// let t3 = spawn_task(3);
+    ///
+    /// // Run the tasks in order of priority.
+    /// let mut metadata_seen = vec![];
+    /// while let Some(TaskWrapper(runnable)) = EXECUTOR.lock().unwrap().pop() {
+    ///     metadata_seen.push(*runnable.metadata());
+    ///     runnable.run();
+    /// }
+    ///
+    /// assert_eq!(metadata_seen, vec![3, 2, 1]);
+    /// assert_eq!(t1.await, 1);
+    /// assert_eq!(t2.await, 2);
+    /// assert_eq!(t3.await, 3);
+    /// # });
+    /// ```
+    pub fn metadata<M>(self, metadata: M) -> Builder<M> {
+        Builder { metadata }
+    }
+}
+
+impl<M> Builder<M> {
+    /// Creates a new task.
+    ///
+    /// The returned [`Runnable`] is used to poll the `future`, and the [`Task`] is used to await its
+    /// output.
+    ///
+    /// Method [`run()`][`Runnable::run()`] polls the task's future once. Then, the [`Runnable`]
+    /// vanishes and only reappears when its [`Waker`] wakes the task, thus scheduling it to be run
+    /// again.
+    ///
+    /// When the task is woken, its [`Runnable`] is passed to the `schedule` function.
+    /// The `schedule` function should not attempt to run the [`Runnable`] nor to drop it. Instead, it
+    /// should push it into a task queue so that it can be processed later.
+    ///
+    /// If you need to spawn a future that does not implement [`Send`] or isn't `'static`, consider
+    /// using [`spawn_local()`] or [`spawn_unchecked()`] instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_task::Builder;
+    ///
+    /// // The future inside the task.
+    /// let future = async {
+    ///     println!("Hello, world!");
+    /// };
+    ///
+    /// // A function that schedules the task when it gets woken up.
+    /// let (s, r) = flume::unbounded();
+    /// let schedule = move |runnable| s.send(runnable).unwrap();
+    ///
+    /// // Create a task with the future and the schedule function.
+    /// let (runnable, task) = Builder::new().spawn(future, schedule);
+    /// ```
+    pub fn spawn<F, S>(self, future: F, schedule: S) -> (Runnable<M>, Task<F::Output, M>)
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+        S: Fn(Runnable<M>) + Send + Sync + 'static,
+    {
+        unsafe { self.spawn_unchecked(future, schedule) }
+    }
+
+    /// Creates a new thread-local task.
+    ///
+    /// This function is same as [`spawn()`], except it does not require [`Send`] on `future`. If the
+    /// [`Runnable`] is used or dropped on another thread, a panic will occur.
+    ///
+    /// This function is only available when the `std` feature for this crate is enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_task::{Builder, Runnable};
+    /// use flume::{Receiver, Sender};
+    /// use std::rc::Rc;
+    ///
+    /// thread_local! {
+    ///     // A queue that holds scheduled tasks.
+    ///     static QUEUE: (Sender<Runnable>, Receiver<Runnable>) = flume::unbounded();
+    /// }
+    ///
+    /// // Make a non-Send future.
+    /// let msg: Rc<str> = "Hello, world!".into();
+    /// let future = async move {
+    ///     println!("{}", msg);
+    /// };
+    ///
+    /// // A function that schedules the task when it gets woken up.
+    /// let s = QUEUE.with(|(s, _)| s.clone());
+    /// let schedule = move |runnable| s.send(runnable).unwrap();
+    ///
+    /// // Create a task with the future and the schedule function.
+    /// let (runnable, task) = Builder::new().spawn_local(future, schedule);
+    /// ```
+    #[cfg(feature = "std")]
+    pub fn spawn_local<F, S>(self, future: F, schedule: S) -> (Runnable<M>, Task<F::Output, M>)
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+        S: Fn(Runnable<M>) + Send + Sync + 'static,
+    {
+        use std::mem::ManuallyDrop;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use std::thread::{self, ThreadId};
+
+        #[inline]
+        fn thread_id() -> ThreadId {
+            thread_local! {
+                static ID: ThreadId = thread::current().id();
+            }
+            ID.try_with(|id| *id)
+                .unwrap_or_else(|_| thread::current().id())
+        }
+
+        struct Checked<F> {
+            id: ThreadId,
+            inner: ManuallyDrop<F>,
+        }
+
+        impl<F> Drop for Checked<F> {
+            fn drop(&mut self) {
+                assert!(
+                    self.id == thread_id(),
+                    "local task dropped by a thread that didn't spawn it"
+                );
+                unsafe {
+                    ManuallyDrop::drop(&mut self.inner);
+                }
+            }
+        }
+
+        impl<F: Future> Future for Checked<F> {
+            type Output = F::Output;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                assert!(
+                    self.id == thread_id(),
+                    "local task polled by a thread that didn't spawn it"
+                );
+                unsafe { self.map_unchecked_mut(|c| &mut *c.inner).poll(cx) }
+            }
+        }
+
+        // Wrap the future into one that checks which thread it's on.
+        let future = Checked {
+            id: thread_id(),
+            inner: ManuallyDrop::new(future),
+        };
+
+        unsafe { self.spawn_unchecked(future, schedule) }
+    }
+
+    /// Creates a new task without [`Send`], [`Sync`], and `'static` bounds.
+    ///
+    /// This function is same as [`spawn()`], except it does not require [`Send`], [`Sync`], and
+    /// `'static` on `future` and `schedule`.
+    ///
+    /// # Safety
+    ///
+    /// - If `future` is not [`Send`], its [`Runnable`] must be used and dropped on the original
+    ///   thread.
+    /// - If `future` is not `'static`, borrowed variables must outlive its [`Runnable`].
+    /// - If `schedule` is not [`Send`] and [`Sync`], the task's [`Waker`] must be used and dropped on
+    ///   the original thread.
+    /// - If `schedule` is not `'static`, borrowed variables must outlive the task's [`Waker`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_task::Builder;
+    ///
+    /// // The future inside the task.
+    /// let future = async {
+    ///     println!("Hello, world!");
+    /// };
+    ///
+    /// // If the task gets woken up, it will be sent into this channel.
+    /// let (s, r) = flume::unbounded();
+    /// let schedule = move |runnable| s.send(runnable).unwrap();
+    ///
+    /// // Create a task with the future and the schedule function.
+    /// let (runnable, task) = unsafe { Builder::new().spawn_unchecked(future, schedule) };
+    /// ```
+    pub unsafe fn spawn_unchecked<F, S>(
+        self,
+        future: F,
+        schedule: S,
+    ) -> (Runnable<M>, Task<F::Output, M>)
+    where
+        F: Future,
+        S: Fn(Runnable<M>),
+    {
+        // Allocate large futures on the heap.
+        let Self { metadata } = self;
+        let ptr = if mem::size_of::<F>() >= 2048 {
+            let future = alloc::boxed::Box::pin(future);
+            RawTask::<_, F::Output, S, M>::allocate(future, schedule, metadata)
+        } else {
+            RawTask::<F, F::Output, S, M>::allocate(future, schedule, metadata)
+        };
+
+        let runnable = Runnable {
+            ptr,
+            _marker: PhantomData,
+        };
+        let task = Task {
+            ptr,
+            _marker: PhantomData,
+        };
+        (runnable, task)
+    }
+}
+
 /// Creates a new task.
 ///
 /// The returned [`Runnable`] is used to poll the `future`, and the [`Task`] is used to await its
@@ -90,56 +399,7 @@ where
     F::Output: 'static,
     S: Fn(Runnable) + Send + Sync + 'static,
 {
-    use std::mem::ManuallyDrop;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use std::thread::{self, ThreadId};
-
-    #[inline]
-    fn thread_id() -> ThreadId {
-        thread_local! {
-            static ID: ThreadId = thread::current().id();
-        }
-        ID.try_with(|id| *id)
-            .unwrap_or_else(|_| thread::current().id())
-    }
-
-    struct Checked<F> {
-        id: ThreadId,
-        inner: ManuallyDrop<F>,
-    }
-
-    impl<F> Drop for Checked<F> {
-        fn drop(&mut self) {
-            assert!(
-                self.id == thread_id(),
-                "local task dropped by a thread that didn't spawn it"
-            );
-            unsafe {
-                ManuallyDrop::drop(&mut self.inner);
-            }
-        }
-    }
-
-    impl<F: Future> Future for Checked<F> {
-        type Output = F::Output;
-
-        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            assert!(
-                self.id == thread_id(),
-                "local task polled by a thread that didn't spawn it"
-            );
-            unsafe { self.map_unchecked_mut(|c| &mut *c.inner).poll(cx) }
-        }
-    }
-
-    // Wrap the future into one that checks which thread it's on.
-    let future = Checked {
-        id: thread_id(),
-        inner: ManuallyDrop::new(future),
-    };
-
-    unsafe { spawn_unchecked(future, schedule) }
+    Builder::new().spawn_local(future, schedule)
 }
 
 /// Creates a new task without [`Send`], [`Sync`], and `'static` bounds.
@@ -176,20 +436,7 @@ where
     F: Future,
     S: Fn(Runnable),
 {
-    // Allocate large futures on the heap.
-    let ptr = if mem::size_of::<F>() >= 2048 {
-        let future = alloc::boxed::Box::pin(future);
-        RawTask::<_, F::Output, S>::allocate(future, schedule)
-    } else {
-        RawTask::<F, F::Output, S>::allocate(future, schedule)
-    };
-
-    let runnable = Runnable { ptr };
-    let task = Task {
-        ptr,
-        _marker: PhantomData,
-    };
-    (runnable, task)
+    Builder::new().spawn_unchecked(future, schedule)
 }
 
 /// A handle to a runnable task.
@@ -230,20 +477,31 @@ where
 /// runnable.schedule();
 /// assert_eq!(smol::future::block_on(task), 3);
 /// ```
-pub struct Runnable {
+pub struct Runnable<M = ()> {
     /// A pointer to the heap-allocated task.
     pub(crate) ptr: NonNull<()>,
+
+    /// A marker capturing generic type `M`.
+    pub(crate) _marker: PhantomData<M>,
 }
 
-unsafe impl Send for Runnable {}
-unsafe impl Sync for Runnable {}
+unsafe impl<M: Send + Sync> Send for Runnable<M> {}
+unsafe impl<M: Send + Sync> Sync for Runnable<M> {}
 
 #[cfg(feature = "std")]
-impl std::panic::UnwindSafe for Runnable {}
+impl<M> std::panic::UnwindSafe for Runnable<M> {}
 #[cfg(feature = "std")]
-impl std::panic::RefUnwindSafe for Runnable {}
+impl<M> std::panic::RefUnwindSafe for Runnable<M> {}
 
-impl Runnable {
+impl<M> Runnable<M> {
+    /// Get the metadata associated with this task.
+    ///
+    /// Tasks can be created with a metadata object associated with them; by default, this
+    /// is a `()` value. See the [`Builder::metadata()`] method for more information.
+    pub fn metadata(&self) -> &M {
+        &self.header().metadata
+    }
+
     /// Schedules the task.
     ///
     /// This is a convenience method that passes the [`Runnable`] to the schedule function.
@@ -265,7 +523,7 @@ impl Runnable {
     /// ```
     pub fn schedule(self) {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
         mem::forget(self);
 
         unsafe {
@@ -303,7 +561,7 @@ impl Runnable {
     /// ```
     pub fn run(self) -> bool {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
         mem::forget(self);
 
         unsafe { ((*header).vtable.run)(ptr) }
@@ -334,22 +592,26 @@ impl Runnable {
     /// ```
     pub fn waker(&self) -> Waker {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         unsafe {
             let raw_waker = ((*header).vtable.clone_waker)(ptr);
             Waker::from_raw(raw_waker)
         }
     }
+
+    fn header(&self) -> &Header<M> {
+        unsafe { &*(self.ptr.as_ptr() as *const Header<M>) }
+    }
 }
 
-impl Drop for Runnable {
+impl<M> Drop for Runnable<M> {
     fn drop(&mut self) {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = self.header();
 
         unsafe {
-            let mut state = (*header).state.load(Ordering::Acquire);
+            let mut state = header.state.load(Ordering::Acquire);
 
             loop {
                 // If the task has been completed or closed, it can't be canceled.
@@ -358,7 +620,7 @@ impl Drop for Runnable {
                 }
 
                 // Mark the task as closed.
-                match (*header).state.compare_exchange_weak(
+                match header.state.compare_exchange_weak(
                     state,
                     state | CLOSED,
                     Ordering::AcqRel,
@@ -370,10 +632,10 @@ impl Drop for Runnable {
             }
 
             // Drop the future.
-            ((*header).vtable.drop_future)(ptr);
+            (header.vtable.drop_future)(ptr);
 
             // Mark the task as unscheduled.
-            let state = (*header).state.fetch_and(!SCHEDULED, Ordering::AcqRel);
+            let state = header.state.fetch_and(!SCHEDULED, Ordering::AcqRel);
 
             // Notify the awaiter that the future has been dropped.
             if state & AWAITER != 0 {
@@ -381,15 +643,15 @@ impl Drop for Runnable {
             }
 
             // Drop the task reference.
-            ((*header).vtable.drop_ref)(ptr);
+            (header.vtable.drop_ref)(ptr);
         }
     }
 }
 
-impl fmt::Debug for Runnable {
+impl<M: fmt::Debug> fmt::Debug for Runnable<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         f.debug_struct("Runnable")
             .field("header", unsafe { &(*header) })

--- a/src/task.rs
+++ b/src/task.rs
@@ -44,25 +44,25 @@ use crate::state::*;
 /// assert_eq!(future::block_on(task), 3);
 /// ```
 #[must_use = "tasks get canceled when dropped, use `.detach()` to run them in the background"]
-pub struct Task<T> {
+pub struct Task<T, M = ()> {
     /// A raw task pointer.
     pub(crate) ptr: NonNull<()>,
 
-    /// A marker capturing generic type `T`.
-    pub(crate) _marker: PhantomData<T>,
+    /// A marker capturing generic types `T` and `M`.
+    pub(crate) _marker: PhantomData<(T, M)>,
 }
 
-unsafe impl<T: Send> Send for Task<T> {}
-unsafe impl<T> Sync for Task<T> {}
+unsafe impl<T: Send, M: Send + Sync> Send for Task<T, M> {}
+unsafe impl<T, M: Send + Sync> Sync for Task<T, M> {}
 
-impl<T> Unpin for Task<T> {}
+impl<T, M> Unpin for Task<T, M> {}
 
 #[cfg(feature = "std")]
-impl<T> std::panic::UnwindSafe for Task<T> {}
+impl<T, M> std::panic::UnwindSafe for Task<T, M> {}
 #[cfg(feature = "std")]
-impl<T> std::panic::RefUnwindSafe for Task<T> {}
+impl<T, M> std::panic::RefUnwindSafe for Task<T, M> {}
 
-impl<T> Task<T> {
+impl<T, M> Task<T, M> {
     /// Detaches the task to let it keep running in the background.
     ///
     /// # Examples
@@ -173,14 +173,14 @@ impl<T> Task<T> {
     /// // Wait for the task's output.
     /// assert_eq!(future::block_on(task.fallible()), None);
     /// ```
-    pub fn fallible(self) -> FallibleTask<T> {
+    pub fn fallible(self) -> FallibleTask<T, M> {
         FallibleTask { task: self }
     }
 
     /// Puts the task in canceled state.
     fn set_canceled(&mut self) {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         unsafe {
             let mut state = (*header).state.load(Ordering::Acquire);
@@ -228,7 +228,7 @@ impl<T> Task<T> {
     /// Puts the task in detached state.
     fn set_detached(&mut self) -> Option<T> {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         unsafe {
             // A place where the output will be stored in case it needs to be dropped.
@@ -316,7 +316,7 @@ impl<T> Task<T> {
     /// 4. It is completed and the `Task` gets dropped.
     fn poll_task(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         unsafe {
             let mut state = (*header).state.load(Ordering::Acquire);
@@ -391,9 +391,9 @@ impl<T> Task<T> {
         }
     }
 
-    fn header(&self) -> &Header {
+    fn header(&self) -> &Header<M> {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
         unsafe { &*header }
     }
 
@@ -402,23 +402,31 @@ impl<T> Task<T> {
     /// Note that in a multithreaded environment, this task can change finish immediately after calling this function.
     pub fn is_finished(&self) -> bool {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header;
+        let header = ptr as *const Header<M>;
 
         unsafe {
             let state = (*header).state.load(Ordering::Acquire);
             state & (CLOSED | COMPLETED) != 0
         }
     }
+
+    /// Get the metadata associated with this task.
+    ///
+    /// Tasks can be created with a metadata object associated with them; by default, this
+    /// is a `()` value. See the [`Builder::metadata()`] method for more information.
+    pub fn metadata(&self) -> &M {
+        &self.header().metadata
+    }
 }
 
-impl<T> Drop for Task<T> {
+impl<T, M> Drop for Task<T, M> {
     fn drop(&mut self) {
         self.set_canceled();
         self.set_detached();
     }
 }
 
-impl<T> Future for Task<T> {
+impl<T, M> Future for Task<T, M> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -429,7 +437,7 @@ impl<T> Future for Task<T> {
     }
 }
 
-impl<T> fmt::Debug for Task<T> {
+impl<T, M: fmt::Debug> fmt::Debug for Task<T, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Task")
             .field("header", self.header())
@@ -446,11 +454,11 @@ impl<T> fmt::Debug for Task<T> {
 /// This can be useful to avoid the panic produced when polling the `Task`
 /// future if the executor dropped its `Runnable`.
 #[must_use = "tasks get canceled when dropped, use `.detach()` to run them in the background"]
-pub struct FallibleTask<T> {
-    task: Task<T>,
+pub struct FallibleTask<T, M> {
+    task: Task<T, M>,
 }
 
-impl<T> FallibleTask<T> {
+impl<T, M> FallibleTask<T, M> {
     /// Detaches the task to let it keep running in the background.
     ///
     /// # Examples
@@ -515,7 +523,7 @@ impl<T> FallibleTask<T> {
     }
 }
 
-impl<T> Future for FallibleTask<T> {
+impl<T, M> Future for FallibleTask<T, M> {
     type Output = Option<T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -523,7 +531,7 @@ impl<T> Future for FallibleTask<T> {
     }
 }
 
-impl<T> fmt::Debug for FallibleTask<T> {
+impl<T, M: fmt::Debug> fmt::Debug for FallibleTask<T, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FallibleTask")
             .field("header", self.task.header())

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -51,7 +51,7 @@ fn metadata_use_case() {
     }
 
     // Unwrap the tasks.
-    smol::block_on(async move {
+    smol::future::block_on(async move {
         t1.await;
         t2.await;
     });

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,0 +1,58 @@
+use async_task::{Builder, Runnable};
+use flume::unbounded;
+use smol::future;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn metadata_use_case() {
+    // Each future has a counter that is incremented every time it is scheduled.
+    let (sender, receiver) = unbounded::<Runnable<AtomicUsize>>();
+    let schedule = move |runnable: Runnable<AtomicUsize>| {
+        runnable.metadata().fetch_add(1, Ordering::SeqCst);
+        sender.send(runnable).ok();
+    };
+
+    async fn my_future(counter: &AtomicUsize) {
+        loop {
+            // Loop until we've been scheduled five times.
+            let count = counter.load(Ordering::SeqCst);
+            if count < 5 {
+                // Make sure that we are immediately scheduled again.
+                future::yield_now().await;
+                continue;
+            }
+
+            // We've been scheduled five times, so we're done.
+            break;
+        }
+    }
+
+    let make_task = || {
+        // SAFETY: We are spawning a non-'static future, so we need to use the unsafe API.
+        // The borrowed variables, in this case the metadata, are guaranteed to outlive the runnable.
+        let (runnable, task) = unsafe {
+            Builder::new()
+                .metadata(AtomicUsize::new(0))
+                .spawn_unchecked(my_future, schedule.clone())
+        };
+
+        runnable.schedule();
+        task
+    };
+
+    // Make tasks.
+    let t1 = make_task();
+    let t2 = make_task();
+
+    // Run the tasks.
+    while let Ok(runnable) = receiver.try_recv() {
+        runnable.run();
+    }
+
+    // Unwrap the tasks.
+    smol::block_on(async move {
+        t1.await;
+        t2.await;
+    });
+}


### PR DESCRIPTION
In the course of resolving #31, I realized that users may want to associate other things with tasks, like string names, priorities, debugger information, and otherwise. This PR adds a new generic field to both `Task` and `Runnable`, `M`. By default, `M` is the unit type, `()`, in order to keep consistency with the previous operation of this crate. This metadata is stored in the allocation and can be accessed via the `metadata()` function on both `Task` and `Runnable`.

In order to create new tasks with metadata, I've introduced a new `Builder` structure. This builder expands on the previous `spawn_*` family of functions by providing a `metadata()` function that creates the task using a generic piece of metadata. `Builder` may be useful later on for solving #24 once allocator APIs are stable.

This is a minor version bump; `Task`s use `()` as their default `M` parameter to ensure that the logic is kept consistent.

Discussion questions:

- Since `M` is essentially stored in an `Arc`, I've added `M: Send + Sync` bounds to the `impl Send/Sync` for both the `Task` and the `Runnable.` Is this right?
- In order to make the metadata more useful, there may be a way to somehow make the metadata available to the current future. However, I'm not sure if there's a safe way of doing this.

Closes #31