### PR TITLE
Add FallibleTask::is_finished()

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -513,6 +513,13 @@ impl<T> FallibleTask<T> {
     pub async fn cancel(self) -> Option<T> {
         self.task.cancel().await
     }
+
+    /// Returns `true` if the current task is finished.
+    ///
+    /// Note that in a multithreaded environment, this task can change finish immediately after calling this function.
+    pub fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
 }
 
 impl<T> Future for FallibleTask<T> {


### PR DESCRIPTION
I'm unsure if there is a reason why this didn't exist already, but it seems straightforward to me.