### PR TITLE
Add `woken_while_running` as another argument to the scheduling function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ mod state;
 mod task;
 mod utils;
 
-pub use crate::runnable::{spawn, spawn_unchecked, Builder, Runnable};
+pub use crate::runnable::{spawn, spawn2, spawn_unchecked, spawn_unchecked2, Builder, Runnable};
 pub use crate::task::{FallibleTask, Task};
 
 #[cfg(feature = "std")]
-pub use crate::runnable::spawn_local;
+pub use crate::runnable::{spawn_local, spawn_local2};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,10 @@ mod state;
 mod task;
 mod utils;
 
-pub use crate::runnable::{spawn, spawn2, spawn_unchecked, spawn_unchecked2, Builder, Runnable};
+pub use crate::runnable::{
+    spawn, spawn_unchecked, Builder, Runnable, Schedule, ScheduleInfo, WithInfo,
+};
 pub use crate::task::{FallibleTask, Task};
 
 #[cfg(feature = "std")]
-pub use crate::runnable::{spawn_local, spawn_local2};
+pub use crate::runnable::spawn_local;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -280,12 +280,7 @@ where
                         // time to schedule it.
                         if state & RUNNING == 0 {
                             // Schedule the task.
-                            Self::schedule(
-                                ptr,
-                                ScheduleInfo {
-                                    woken_while_running: false,
-                                },
-                            );
+                            Self::schedule(ptr, ScheduleInfo::new(false));
                         } else {
                             // Drop the waker.
                             Self::drop_waker(ptr);
@@ -354,12 +349,7 @@ where
                                 ptr: NonNull::new_unchecked(ptr as *mut ()),
                                 _marker: PhantomData,
                             };
-                            (*raw.schedule).schedule(
-                                task,
-                                ScheduleInfo {
-                                    woken_while_running: false,
-                                },
-                            );
+                            (*raw.schedule).schedule(task, ScheduleInfo::new(false));
                         }
 
                         break;
@@ -407,12 +397,7 @@ where
                 (*raw.header)
                     .state
                     .store(SCHEDULED | CLOSED | REFERENCE, Ordering::Release);
-                Self::schedule(
-                    ptr,
-                    ScheduleInfo {
-                        woken_while_running: false,
-                    },
-                );
+                Self::schedule(ptr, ScheduleInfo::new(false));
             } else {
                 // Otherwise, destroy the task right away.
                 Self::destroy(ptr);
@@ -678,12 +663,7 @@ where
                             } else if state & SCHEDULED != 0 {
                                 // The thread that woke the task up didn't reschedule it because
                                 // it was running so now it's our responsibility to do so.
-                                Self::schedule(
-                                    ptr,
-                                    ScheduleInfo {
-                                        woken_while_running: true,
-                                    },
-                                );
+                                Self::schedule(ptr, ScheduleInfo::new(true));
                                 return true;
                             } else {
                                 // Drop the task reference.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -9,6 +9,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use crate::header::Header;
+use crate::runnable::{Schedule, ScheduleInfo};
 use crate::state::*;
 use crate::utils::{abort, abort_on_panic, max, Layout};
 use crate::Runnable;
@@ -22,7 +23,7 @@ pub(crate) type Panic = core::convert::Infallible;
 /// The vtable for a task.
 pub(crate) struct TaskVTable {
     /// Schedules the task.
-    pub(crate) schedule: unsafe fn(*const (), bool),
+    pub(crate) schedule: unsafe fn(*const (), ScheduleInfo),
 
     /// Drops the future inside the task.
     pub(crate) drop_future: unsafe fn(*const ()),
@@ -129,7 +130,7 @@ impl<F, T, S, M> RawTask<F, T, S, M> {
 impl<F, T, S, M> RawTask<F, T, S, M>
 where
     F: Future<Output = T>,
-    S: Fn(Runnable<M>, bool),
+    S: Schedule<M>,
 {
     const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
         Self::clone_waker,
@@ -279,7 +280,12 @@ where
                         // time to schedule it.
                         if state & RUNNING == 0 {
                             // Schedule the task.
-                            Self::schedule(ptr, false);
+                            Self::schedule(
+                                ptr,
+                                ScheduleInfo {
+                                    woken_while_running: false,
+                                },
+                            );
                         } else {
                             // Drop the waker.
                             Self::drop_waker(ptr);
@@ -348,7 +354,12 @@ where
                                 ptr: NonNull::new_unchecked(ptr as *mut ()),
                                 _marker: PhantomData,
                             };
-                            (*raw.schedule)(task, false);
+                            (*raw.schedule).schedule(
+                                task,
+                                ScheduleInfo {
+                                    woken_while_running: false,
+                                },
+                            );
                         }
 
                         break;
@@ -396,7 +407,12 @@ where
                 (*raw.header)
                     .state
                     .store(SCHEDULED | CLOSED | REFERENCE, Ordering::Release);
-                Self::schedule(ptr, true);
+                Self::schedule(
+                    ptr,
+                    ScheduleInfo {
+                        woken_while_running: false,
+                    },
+                );
             } else {
                 // Otherwise, destroy the task right away.
                 Self::destroy(ptr);
@@ -426,7 +442,7 @@ where
     ///
     /// This function doesn't modify the state of the task. It only passes the task reference to
     /// its schedule function.
-    unsafe fn schedule(ptr: *const (), woken_while_running: bool) {
+    unsafe fn schedule(ptr: *const (), info: ScheduleInfo) {
         let raw = Self::from_ptr(ptr);
 
         // If the schedule function has captured variables, create a temporary waker that prevents
@@ -440,7 +456,7 @@ where
             ptr: NonNull::new_unchecked(ptr as *mut ()),
             _marker: PhantomData,
         };
-        (*raw.schedule)(task, woken_while_running);
+        (*raw.schedule).schedule(task, info);
     }
 
     /// Drops the future inside a task.
@@ -662,7 +678,12 @@ where
                             } else if state & SCHEDULED != 0 {
                                 // The thread that woke the task up didn't reschedule it because
                                 // it was running so now it's our responsibility to do so.
-                                Self::schedule(ptr, true);
+                                Self::schedule(
+                                    ptr,
+                                    ScheduleInfo {
+                                        woken_while_running: true,
+                                    },
+                                );
                                 return true;
                             } else {
                                 // Drop the task reference.
@@ -682,12 +703,12 @@ where
         struct Guard<F, T, S, M>(RawTask<F, T, S, M>)
         where
             F: Future<Output = T>,
-            S: Fn(Runnable<M>, bool);
+            S: Schedule<M>;
 
         impl<F, T, S, M> Drop for Guard<F, T, S, M>
         where
             F: Future<Output = T>,
-            S: Fn(Runnable<M>, bool),
+            S: Schedule<M>,
         {
             fn drop(&mut self) {
                 let raw = self.0;

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -13,6 +13,15 @@ use crate::raw::RawTask;
 use crate::state::*;
 use crate::Task;
 
+mod sealed {
+    use super::*;
+    pub trait Sealed<M> {}
+
+    impl<M, F> Sealed<M> for F where F: Fn(Runnable<M>) {}
+
+    impl<M, F> Sealed<M> for WithInfo<F> where F: Fn(Runnable<M>, ScheduleInfo) {}
+}
+
 /// A builder that creates a new task.
 #[derive(Debug)]
 pub struct Builder<M> {
@@ -27,6 +36,114 @@ pub struct Builder<M> {
 impl<M: Default> Default for Builder<M> {
     fn default() -> Self {
         Builder::new().metadata(M::default())
+    }
+}
+
+/// Extra scheduling information that can be acquired by the scheduling
+/// function.
+///
+/// Note: The data source of this struct is directly from the actual
+/// implementation of the crate itself, different from [`Runnable`]'s metadata,
+/// which is managed by the caller.
+///
+/// # Examples
+///
+/// ```
+/// use async_task::{Runnable, ScheduleInfo, WithInfo};
+/// use std::sync::{Arc, Mutex};
+///
+/// // If the task gets woken up while running, it will be sent into this channel.
+/// let (s, r) = flume::unbounded();
+/// // Otherwise, it will be placed into this slot.
+/// let lifo_slot = Arc::new(Mutex::new(None));
+/// let schedule = move |runnable: Runnable, info: ScheduleInfo| {
+///     if info.woken_while_running {
+///         s.send(runnable).unwrap()
+///     } else {
+///         let last = lifo_slot.lock().unwrap().replace(runnable);
+///         if let Some(last) = last {
+///             s.send(last).unwrap()
+///         }
+///     }
+/// };
+///
+/// // Create the actual scheduler to be spawned with some future.
+/// let scheduler = WithInfo(schedule);
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub struct ScheduleInfo {
+    /// Indicates whether the task gets woken up while running.
+    ///
+    /// It is set to true usually because the task has yielded itself to the
+    /// scheduler.
+    pub woken_while_running: bool,
+}
+
+/// The trait for scheduling functions.
+pub trait Schedule<M = ()>: sealed::Sealed<M> {
+    /// The actual scheduling procedure.
+    fn schedule(&self, runnable: Runnable<M>, info: ScheduleInfo);
+}
+
+impl<M, F> Schedule<M> for F
+where
+    F: Fn(Runnable<M>),
+{
+    fn schedule(&self, runnable: Runnable<M>, _: ScheduleInfo) {
+        self(runnable)
+    }
+}
+
+/// Pass a scheduling function with more scheduling information - a.k.a.
+/// [`ScheduleInfo`].
+///
+/// Sometimes, it's useful to pass the runnable's state directly to the
+/// scheduling function, such as whether it's woken up while running. The
+/// scheduler can thus use the information to determine its scheduling
+/// strategy.
+///
+/// Note: The data source of [`ScheduleInfo`] is directly from the actual
+/// implementation of the crate itself, different from [`Runnable`]'s metadata,
+/// which is managed by the caller.
+///
+/// # Examples
+///
+/// ```
+/// use async_task::{ScheduleInfo, WithInfo};
+/// use std::sync::{Arc, Mutex};
+///
+/// // The future inside the task.
+/// let future = async {
+///     println!("Hello, world!");
+/// };
+///
+/// // If the task gets woken up while running, it will be sent into this channel.
+/// let (s, r) = flume::unbounded();
+/// // Otherwise, it will be placed into this slot.
+/// let lifo_slot = Arc::new(Mutex::new(None));
+/// let schedule = move |runnable, info: ScheduleInfo| {
+///     if info.woken_while_running {
+///         s.send(runnable).unwrap()
+///     } else {
+///         let last = lifo_slot.lock().unwrap().replace(runnable);
+///         if let Some(last) = last {
+///             s.send(last).unwrap()
+///         }
+///     }
+/// };
+///
+/// // Create a task with the future and the schedule function.
+/// let (runnable, task) = async_task::spawn(future, WithInfo(schedule));
+/// ```
+#[derive(Debug)]
+pub struct WithInfo<F>(pub F);
+
+impl<M, F> Schedule<M> for WithInfo<F>
+where
+    F: Fn(Runnable<M>, ScheduleInfo),
+{
+    fn schedule(&self, runnable: Runnable<M>, info: ScheduleInfo) {
+        (self.0)(runnable, info)
     }
 }
 
@@ -226,68 +343,9 @@ impl<M> Builder<M> {
         F: FnOnce(&M) -> Fut,
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
-        S: Fn(Runnable<M>) + Send + Sync + 'static,
+        S: Schedule<M> + Send + Sync + 'static,
     {
         unsafe { self.spawn_unchecked(future, schedule) }
-    }
-
-    /// Creates a new task, with an additional argument in the schedule function.
-    ///
-    /// The returned [`Runnable`] is used to poll the `future`, and the [`Task`] is used to await its
-    /// output.
-    ///
-    /// Method [`run()`][`Runnable::run()`] polls the task's future once. Then, the [`Runnable`]
-    /// vanishes and only reappears when its [`Waker`] wakes the task, thus scheduling it to be run
-    /// again.
-    ///
-    /// When the task is woken, its [`Runnable`] is passed to the `schedule` function.
-    /// The `schedule` function should not attempt to run the [`Runnable`] nor to drop it. Instead, it
-    /// should push it into a task queue so that it can be processed later.
-    ///
-    /// If you need to spawn a future that does not implement [`Send`] or isn't `'static`, consider
-    /// using [`spawn_local2()`] or [`spawn_unchecked2()`] instead.
-    ///
-    /// # Arguments
-    ///
-    /// - `woken_while_running` - the second argument in the schedule function, set true when the
-    ///   task is woken up while running.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_task::Builder;
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// // The future inside the task.
-    /// let future = async {
-    ///     println!("Hello, world!");
-    /// };
-    ///
-    /// // A function that schedules the task when it gets woken up while runninng.
-    /// let (s, r) = flume::unbounded();
-    /// // Otherwise, it will be placed into this slot.
-    /// let lifo_slot = Arc::new(Mutex::new(None));
-    /// let schedule = move |runnable, woken_while_running| {
-    ///     if woken_while_running {
-    ///         s.send(runnable).unwrap()
-    ///     } else {
-    ///         let last = lifo_slot.lock().unwrap().replace(runnable);
-    ///         if let Some(last) = last {
-    ///             s.send(last).unwrap()
-    ///         }
-    ///     }
-    /// };
-    /// // Create a task with the future and the schedule function.
-    /// let (runnable, task) = Builder::new().spawn2(|()| future, schedule);
-    /// ```
-    pub fn spawn2<F, Fut, S>(self, future: F, schedule: S) -> (Runnable<M>, Task<Fut::Output, M>)
-    where
-        F: FnOnce(&M) -> Fut,
-        Fut: Future + Send + 'static,
-        Fut::Output: Send + 'static,
-        S: Fn(Runnable<M>, bool) + Send + Sync + 'static,
-    {
-        unsafe { self.spawn_unchecked2(future, schedule) }
     }
 
     /// Creates a new thread-local task.
@@ -332,70 +390,7 @@ impl<M> Builder<M> {
         F: FnOnce(&M) -> Fut,
         Fut: Future + 'static,
         Fut::Output: 'static,
-        S: Fn(Runnable<M>) + Send + Sync + 'static,
-    {
-        self.spawn_local2(future, move |runnable, _| schedule(runnable))
-    }
-
-    /// Creates a new thread-local task, with an additional argument in the schedule function..
-    ///
-    /// This function is same as [`spawn()`], except it does not require [`Send`] on `future`. If the
-    /// [`Runnable`] is used or dropped on another thread, a panic will occur.
-    ///
-    /// This function is only available when the `std` feature for this crate is enabled.
-    ///
-    /// # Arguments
-    ///
-    /// - `woken_while_running` - the second argument in the schedule function, set true when the
-    ///   task is woken up while running.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_task::{Builder, Runnable};
-    /// use flume::{Receiver, Sender};
-    /// use std::{rc::Rc, cell::RefCell};
-    ///
-    /// thread_local! {
-    ///     // A queue that holds scheduled tasks.
-    ///     static QUEUE: (Sender<Runnable>, Receiver<Runnable>) = flume::unbounded();
-    ///
-    ///     // A slot intended to be fetched first when picking tasks to run.
-    ///     static LIFO_SLOT: RefCell<Option<Runnable>> = RefCell::new(None);
-    /// }
-    ///
-    /// // Make a non-Send future.
-    /// let msg: Rc<str> = "Hello, world!".into();
-    /// let future = async move {
-    ///     println!("{}", msg);
-    /// };
-    ///
-    /// // A function that schedules the task when it gets woken up.
-    /// let s = QUEUE.with(|(s, _)| s.clone());
-    /// let schedule = move |runnable, woken_while_running| {
-    ///     if woken_while_running {
-    ///         s.send(runnable).unwrap()
-    ///     } else {
-    ///         let last = LIFO_SLOT.with(|slot| slot.borrow_mut().replace(runnable));
-    ///         if let Some(last) = last {
-    ///             s.send(last).unwrap()
-    ///         }
-    ///     }
-    /// };
-    /// // Create a task with the future and the schedule function.
-    /// let (runnable, task) = Builder::new().spawn_local2(move |()| future, schedule);
-    /// ```
-    #[cfg(feature = "std")]
-    pub fn spawn_local2<F, Fut, S>(
-        self,
-        future: F,
-        schedule: S,
-    ) -> (Runnable<M>, Task<Fut::Output, M>)
-    where
-        F: FnOnce(&M) -> Fut,
-        Fut: Future + 'static,
-        Fut::Output: 'static,
-        S: Fn(Runnable<M>, bool) + Send + Sync + 'static,
+        S: Schedule<M> + Send + Sync + 'static,
     {
         use std::mem::ManuallyDrop;
         use std::pin::Pin;
@@ -450,7 +445,7 @@ impl<M> Builder<M> {
             }
         };
 
-        unsafe { self.spawn_unchecked2(future, schedule) }
+        unsafe { self.spawn_unchecked(future, schedule) }
     }
 
     /// Creates a new task without [`Send`], [`Sync`], and `'static` bounds.
@@ -492,70 +487,7 @@ impl<M> Builder<M> {
     where
         F: FnOnce(&'a M) -> Fut,
         Fut: Future + 'a,
-        S: Fn(Runnable<M>),
-        M: 'a,
-    {
-        self.spawn_unchecked2(future, move |task, _| schedule(task))
-    }
-
-    /// Creates a new task without [`Send`], [`Sync`], and `'static` bounds, with an additional argument
-    /// in the schedule function.
-    ///
-    /// This function is same as [`spawn()`], except it does not require [`Send`], [`Sync`], and
-    /// `'static` on `future` and `schedule`.
-    ///
-    /// # Arguments
-    ///
-    /// - `woken_while_running` - the second argument in the schedule function, set true when the
-    ///   task is woken up while running.
-    ///
-    /// # Safety
-    ///
-    /// - If `future`'s output is not [`Send`], its [`Runnable`] must be used and dropped on the original
-    ///   thread.
-    /// - If `future`'s output is not `'static`, borrowed variables must outlive its [`Runnable`].
-    /// - If `schedule` is not [`Send`] and [`Sync`], the task's [`Waker`] must be used and dropped on
-    ///   the original thread.
-    /// - If `schedule` is not `'static`, borrowed variables must outlive the task's [`Waker`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_task::Builder;
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// // The future inside the task.
-    /// let future = async {
-    ///     println!("Hello, world!");
-    /// };
-    ///
-    /// // If the task gets woken up while running, it will be sent into this channel.
-    /// let (s, r) = flume::unbounded();
-    /// // Otherwise, it will be placed into this slot.
-    /// let lifo_slot = Arc::new(Mutex::new(None));
-    /// let schedule = move |runnable, woken_while_running| {
-    ///     if woken_while_running {
-    ///         s.send(runnable).unwrap()
-    ///     } else {
-    ///         let last = lifo_slot.lock().unwrap().replace(runnable);
-    ///         if let Some(last) = last {
-    ///             s.send(last).unwrap()
-    ///         }
-    ///     }
-    /// };
-    ///
-    /// // Create a task with the future and the schedule function.
-    /// let (runnable, task) = unsafe { Builder::new().spawn_unchecked2(move |()| future, schedule) };
-    /// ```
-    pub unsafe fn spawn_unchecked2<'a, F, Fut, S>(
-        self,
-        future: F,
-        schedule: S,
-    ) -> (Runnable<M>, Task<Fut::Output, M>)
-    where
-        F: FnOnce(&'a M) -> Fut,
-        Fut: Future + 'a,
-        S: Fn(Runnable<M>, bool),
+        S: Schedule<M>,
         M: 'a,
     {
         // Allocate large futures on the heap.
@@ -617,67 +549,9 @@ pub fn spawn<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
-    S: Fn(Runnable) + Send + Sync + 'static,
+    S: Schedule + Send + Sync + 'static,
 {
     unsafe { spawn_unchecked(future, schedule) }
-}
-
-/// Creates a new task, with an additional argument in the schedule function.
-///
-/// The returned [`Runnable`] is used to poll the `future`, and the [`Task`] is used to await its
-/// output.
-///
-/// Method [`run()`][`Runnable::run()`] polls the task's future once. Then, the [`Runnable`]
-/// vanishes and only reappears when its [`Waker`] wakes the task, thus scheduling it to be run
-/// again.
-///
-/// When the task is woken, its [`Runnable`] is passed to the `schedule` function.
-/// The `schedule` function should not attempt to run the [`Runnable`] nor to drop it. Instead, it
-/// should push it into a task queue so that it can be processed later.
-///
-/// If you need to spawn a future that does not implement [`Send`] or isn't `'static`, consider
-/// using [`spawn_local2()`] or [`spawn_unchecked2()`] instead.
-///
-/// # Arguments
-///
-/// - `woken_while_running` - the second argument in the schedule function, set true when the
-///   task is woken up while running.
-///
-/// # Examples
-///
-/// ```
-/// use async_task::Builder;
-/// use std::sync::{Arc, Mutex};
-///
-/// // The future inside the task.
-/// let future = async {
-///     println!("Hello, world!");
-/// };
-///
-/// // A function that schedules the task when it gets woken up while runninng.
-/// let (s, r) = flume::unbounded();
-/// // Otherwise, it will be placed into this slot.
-/// let lifo_slot = Arc::new(Mutex::new(None));
-/// let schedule = move |runnable, woken_while_running| {
-///     if woken_while_running {
-///         s.send(runnable).unwrap()
-///     } else {
-///         let last = lifo_slot.lock().unwrap().replace(runnable);
-///         if let Some(last) = last {
-///             s.send(last).unwrap()
-///         }
-///     }
-/// };
-/// // Create a task with the future and the schedule function.
-/// let (runnable, task) = Builder::new().spawn2(|()| future, schedule);
-/// ```
-pub fn spawn2<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
-where
-    F: Future + Send + 'static,
-    F::Output: Send + 'static,
-    S: Fn(Runnable, bool) + Send + Sync + 'static,
-{
-    unsafe { spawn_unchecked2(future, schedule) }
 }
 
 /// Creates a new thread-local task.
@@ -717,67 +591,9 @@ pub fn spawn_local<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
 where
     F: Future + 'static,
     F::Output: 'static,
-    S: Fn(Runnable) + Send + Sync + 'static,
+    S: Schedule + Send + Sync + 'static,
 {
     Builder::new().spawn_local(move |()| future, schedule)
-}
-
-/// Creates a new thread-local task, with an additional argument in the schedule function..
-///
-/// This function is same as [`spawn()`], except it does not require [`Send`] on `future`. If the
-/// [`Runnable`] is used or dropped on another thread, a panic will occur.
-///
-/// This function is only available when the `std` feature for this crate is enabled.
-///
-/// # Arguments
-///
-/// - `woken_while_running` - the second argument in the schedule function, set true when the
-///   task is woken up while running.
-///
-/// # Examples
-///
-/// ```
-/// use async_task::{Builder, Runnable};
-/// use flume::{Receiver, Sender};
-/// use std::{rc::Rc, cell::RefCell};
-///
-/// thread_local! {
-///     // A queue that holds scheduled tasks.
-///     static QUEUE: (Sender<Runnable>, Receiver<Runnable>) = flume::unbounded();
-///
-///     // A slot intended to be fetched first when picking tasks to run.
-///     static LIFO_SLOT: RefCell<Option<Runnable>> = RefCell::new(None);
-/// }
-///
-/// // Make a non-Send future.
-/// let msg: Rc<str> = "Hello, world!".into();
-/// let future = async move {
-///     println!("{}", msg);
-/// };
-///
-/// // A function that schedules the task when it gets woken up.
-/// let s = QUEUE.with(|(s, _)| s.clone());
-/// let schedule = move |runnable, woken_while_running| {
-///     if woken_while_running {
-///         s.send(runnable).unwrap()
-///     } else {
-///         let last = LIFO_SLOT.with(|slot| slot.borrow_mut().replace(runnable));
-///         if let Some(last) = last {
-///             s.send(last).unwrap()
-///         }
-///     }
-/// };
-/// // Create a task with the future and the schedule function.
-/// let (runnable, task) = Builder::new().spawn_local2(move |()| future, schedule);
-/// ```
-#[cfg(feature = "std")]
-pub fn spawn_local2<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
-where
-    F: Future + 'static,
-    F::Output: 'static,
-    S: Fn(Runnable, bool) + Send + Sync + 'static,
-{
-    Builder::new().spawn_local2(move |()| future, schedule)
 }
 
 /// Creates a new task without [`Send`], [`Sync`], and `'static` bounds.
@@ -812,66 +628,9 @@ where
 pub unsafe fn spawn_unchecked<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
 where
     F: Future,
-    S: Fn(Runnable),
+    S: Schedule,
 {
     Builder::new().spawn_unchecked(move |()| future, schedule)
-}
-
-/// Creates a new task without [`Send`], [`Sync`], and `'static` bounds, with an additional argument
-/// in the schedule function.
-///
-/// This function is same as [`spawn()`], except it does not require [`Send`], [`Sync`], and
-/// `'static` on `future` and `schedule`.
-///
-/// # Arguments
-///
-/// - `woken_while_running` - the second argument in the schedule function, set true when the
-///   task is woken while running.
-///
-/// # Safety
-///
-/// - If `future`'s output is not [`Send`], its [`Runnable`] must be used and dropped on the original
-///   thread.
-/// - If `future`'s output is not `'static`, borrowed variables must outlive its [`Runnable`].
-/// - If `schedule` is not [`Send`] and [`Sync`], the task's [`Waker`] must be used and dropped on
-///   the original thread.
-/// - If `schedule` is not `'static`, borrowed variables must outlive the task's [`Waker`].
-///
-/// # Examples
-///
-/// ```
-/// use async_task::Builder;
-/// use std::sync::{Arc, Mutex};
-///
-/// // The future inside the task.
-/// let future = async {
-///     println!("Hello, world!");
-/// };
-///
-/// // If the task gets woken up while running, it will be sent into this channel.
-/// let (s, r) = flume::unbounded();
-/// // Otherwise, it will be placed into this slot.
-/// let lifo_slot = Arc::new(Mutex::new(None));
-/// let schedule = move |runnable, woken_while_running| {
-///     if woken_while_running {
-///         s.send(runnable).unwrap()
-///     } else {
-///         let last = lifo_slot.lock().unwrap().replace(runnable);
-///         if let Some(last) = last {
-///             s.send(last).unwrap()
-///         }
-///     }
-/// };
-///
-/// // Create a task with the future and the schedule function.
-/// let (runnable, task) = unsafe { Builder::new().spawn_unchecked2(move |()| future, schedule) };
-/// ```
-pub unsafe fn spawn_unchecked2<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
-where
-    F: Future,
-    S: Fn(Runnable, bool),
-{
-    Builder::new().spawn_unchecked2(move |()| future, schedule)
 }
 
 /// A handle to a runnable task.
@@ -962,7 +721,12 @@ impl<M> Runnable<M> {
         mem::forget(self);
 
         unsafe {
-            ((*header).vtable.schedule)(ptr, false);
+            ((*header).vtable.schedule)(
+                ptr,
+                ScheduleInfo {
+                    woken_while_running: false,
+                },
+            );
         }
     }
 

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -153,6 +153,12 @@ where
 #[derive(Debug)]
 pub struct WithInfo<F>(pub F);
 
+impl<F> From<F> for WithInfo<F> {
+    fn from(value: F) -> Self {
+        WithInfo(value)
+    }
+}
+
 impl<M, F> Schedule<M> for WithInfo<F>
 where
     F: Fn(Runnable<M>, ScheduleInfo),

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -249,7 +249,7 @@ impl<M> Builder<M> {
     ///
     /// # Arguments
     ///
-    /// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+    /// - `woken_while_running` - the second argument in the schedule function, set true when the
     ///   task is woken up while running.
     ///
     /// # Examples
@@ -346,7 +346,7 @@ impl<M> Builder<M> {
     ///
     /// # Arguments
     ///
-    /// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+    /// - `woken_while_running` - the second argument in the schedule function, set true when the
     ///   task is woken up while running.
     ///
     /// # Examples
@@ -507,7 +507,7 @@ impl<M> Builder<M> {
     ///
     /// # Arguments
     ///
-    /// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+    /// - `woken_while_running` - the second argument in the schedule function, set true when the
     ///   task is woken up while running.
     ///
     /// # Safety
@@ -641,7 +641,7 @@ where
 ///
 /// # Arguments
 ///
-/// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+/// - `woken_while_running` - the second argument in the schedule function, set true when the
 ///   task is woken up while running.
 ///
 /// # Examples
@@ -732,7 +732,7 @@ where
 ///
 /// # Arguments
 ///
-/// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+/// - `woken_while_running` - the second argument in the schedule function, set true when the
 ///   task is woken up while running.
 ///
 /// # Examples
@@ -826,7 +826,7 @@ where
 ///
 /// # Arguments
 ///
-/// - `woken_while_running` - e.g. the second argument in the schedule function, set true when the
+/// - `woken_while_running` - the second argument in the schedule function, set true when the
 ///   task is woken while running.
 ///
 /// # Safety

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -42,7 +42,7 @@ impl<M: Default> Default for Builder<M> {
 /// Extra scheduling information that can be passed to the scheduling function.
 ///
 /// The data source of this struct is directly from the actual implementation
-/// of the crate itself, different from [`Runnable`]'s metadata, which is 
+/// of the crate itself, different from [`Runnable`]'s metadata, which is
 /// managed by the caller.
 ///
 /// # Examples

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -495,7 +495,6 @@ impl<M> Builder<M> {
         S: Fn(Runnable<M>),
         M: 'a,
     {
-        // Allocate large futures on the heap.
         self.spawn_unchecked2(future, move |task, _| schedule(task))
     }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -210,7 +210,7 @@ impl<T, M> Task<T, M> {
                         // If the task is not scheduled nor running, schedule it one more time so
                         // that its future gets dropped by the executor.
                         if state & (SCHEDULED | RUNNING) == 0 {
-                            ((*header).vtable.schedule)(ptr);
+                            ((*header).vtable.schedule)(ptr, false);
                         }
 
                         // Notify the awaiter that the task has been closed.
@@ -289,7 +289,7 @@ impl<T, M> Task<T, M> {
                                 // schedule dropping its future or destroy it.
                                 if state & !(REFERENCE - 1) == 0 {
                                     if state & CLOSED == 0 {
-                                        ((*header).vtable.schedule)(ptr);
+                                        ((*header).vtable.schedule)(ptr, false);
                                     } else {
                                         ((*header).vtable.destroy)(ptr);
                                     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -211,12 +211,7 @@ impl<T, M> Task<T, M> {
                         // If the task is not scheduled nor running, schedule it one more time so
                         // that its future gets dropped by the executor.
                         if state & (SCHEDULED | RUNNING) == 0 {
-                            ((*header).vtable.schedule)(
-                                ptr,
-                                ScheduleInfo {
-                                    woken_while_running: false,
-                                },
-                            );
+                            ((*header).vtable.schedule)(ptr, ScheduleInfo::new(false));
                         }
 
                         // Notify the awaiter that the task has been closed.
@@ -295,12 +290,7 @@ impl<T, M> Task<T, M> {
                                 // schedule dropping its future or destroy it.
                                 if state & !(REFERENCE - 1) == 0 {
                                     if state & CLOSED == 0 {
-                                        ((*header).vtable.schedule)(
-                                            ptr,
-                                            ScheduleInfo {
-                                                woken_while_running: false,
-                                            },
-                                        );
+                                        ((*header).vtable.schedule)(ptr, ScheduleInfo::new(false));
                                     } else {
                                         ((*header).vtable.destroy)(ptr);
                                     }


### PR DESCRIPTION
Currently, it has been found that the return value of the `Runnable::run()` function cannot be directly used in the scheduling function. As a result, the scheduler cannot determine whether the task is self-yielding or has been woken up by some external source when it is scheduled to run on some queues.

This situation can occur when a scheduler wants to set up some `lifo_slot` to allow tasks to preempt the normal execution order, but it receives a scheduling request from a self-yielding task that woke itself up while running. In this case, the scheduler cannot let the task preempt and cause a "false-yielding" result or some sort. Therefore, it needs to know whether the task self-yielded or not. However, with the current implementation, the scheduler can only acquire this information AFTER it schedules the task. This means that it needs to schedule the task for a second time, pushing it to the run queue, which not only takes much more time but also sadly moves the possible last preempted task into the run queue as well.

My pull request is to give the information to the scheduling function and let the scheduler determine in the first place, which in fact is inspired by [Tokio](https://tokio.rs/)'s implementation. All the present APIs remain unchanged, and three new kinds of functions, namely `spawn2`, `spawn_local2`, and `spawn_unchecked2`, are added. The names of these functions can be changed if there is a better idea. Also, the corresponding tests have yet to be added.

```rust
/// A new API.
pub fn spawn2<F, S>(future: F, schedule: S) -> (Runnable, Task<F::Output>)
where
    F: Future + Send + 'static,
    F::Output: Send + 'static,
    S: Fn(Runnable, bool) + Send + Sync + 'static,
{
    unsafe { spawn_unchecked2(future, schedule) }
}

/// A present API, redirected to the corresponding new one.
pub unsafe fn spawn_unchecked<'a, F, Fut, S>(
    self,
    future: F,
    schedule: S,
) -> (Runnable<M>, Task<Fut::Output, M>)
where
    F: FnOnce(&'a M) -> Fut,
    Fut: Future + 'a,
    S: Fn(Runnable<M>),
    M: 'a,
{
    self.spawn_unchecked2(future, move |task, _| schedule(task))
}
```
