### PR TITLE
v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 4.4.0
+
+- Ensure that the allocation doesn't exceed `isize::MAX` (#32)
+- Add `FallibleTask::is_finished()` (#34)
+- Add a metadata generic parameter to tasks (#33)
+- Add panic propagation to tasks (#37)
+- Add a way to tell if the task was woken while running from the schedule function (#42)
+
 # Version 4.3.0
 
 - Bump MSRV to Rust 1.47. (#30)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-task"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v4.x.y" git tag
-version = "4.3.0"
+version = "4.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.47"


### PR DESCRIPTION
- Ensure that the allocation doesn't exceed `isize::MAX` (#32)
- Add `FallibleTask::is_finished()` (#34)
- Add a metadata generic parameter to tasks (#33)
- Add panic propagation to tasks (#37)
- Add a way to tell if the task was woken while running from the schedule function (#42)