### PR TITLE
Support for CPU architectures with no atomic instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: cargo test -- --test-threads=1
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=all --track-origins=yes --fair-sched=yes
+      - name: Run cargo test (with portable-atomic enabled)
+        run: cargo test --features portable-atomic
       - name: Clone async-executor
         run: git clone https://github.com/smol-rs/async-executor.git
       - name: Add patch section

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ exclude = ["/.*"]
 default = ["std"]
 std = []
 
+[dependencies]
+# Uses portable-atomic polyfill atomics on targets without them
+portable-atomic = { version = "1", optional = true, default-features = false }
+
 [dev-dependencies]
 atomic-waker = "1"
 easy-parallel = "3"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,12 @@
 use core::cell::UnsafeCell;
 use core::fmt;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::Waker;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
 
 use crate::raw::TaskVTable;
 use crate::state::*;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -5,8 +5,13 @@ use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
 
 use crate::header::Header;
 use crate::runnable::{Schedule, ScheduleInfo};


### PR DESCRIPTION
Addresses #57 

@notgull Seems to be as simple as this?

* Note that I've not touched any of the `dev-dependencies` as they are just used for testing;
* Also, not sure what testing with `portable-atomic` enabled we have to have in the CI (`atomic-waker` had none);
* I've only added a single line `cargo test --features portable-atomic ...` below the existing test run.