### PR TITLE
v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 4.6.0
+
+- Bump MSRV to 1.57. (#63)
+- Task layout computation failures are now a compile-time error instead of a
+  runtime abort. (#63)
+
 # Version 4.5.0
 
 - Add a `portable-atomic` feature that enables the usage of fallback primitives for CPUs without atomics. (#58)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-task"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v4.x.y" git tag
-version = "4.5.0"
+version = "4.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.57"


### PR DESCRIPTION
- Bump MSRV to 1.57. (#63)
- Task layout computation failures are now a compile-time error instead of a runtime abort. (#63)
