### PR TITLE
v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 4.7.0
+
+- Add `from_raw` and `into_raw` functions for `Runnable` to ease passing it
+  across an FFI boundary. (#65)
+
 # Version 4.6.0
 
 - Bump MSRV to 1.57. (#63)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-task"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v4.x.y" git tag
-version = "4.6.0"
+version = "4.7.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.57"


### PR DESCRIPTION
- Add `from_raw` and `into_raw` functions for `Runnable` to ease passing it
  across an FFI boundary. (#65)
