### PR TITLE
Fix CI failure & Migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,11 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.57']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo build
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --feature-powerset --no-dev-deps --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-task"
 # - Create "v4.x.y" git tag
 version = "4.7.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/async-task"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -21,7 +21,7 @@ macro_rules! future {
         static $drop: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = Box<i32>;
@@ -56,7 +56,7 @@ macro_rules! schedule {
         static $sched: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/cancel.rs
+++ b/tests/cancel.rs
@@ -24,7 +24,7 @@ macro_rules! future {
         static $drop_t: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = Out;
@@ -43,7 +43,7 @@ macro_rules! future {
             }
 
             #[derive(Default)]
-            struct Out(Box<i32>, bool);
+            struct Out(#[allow(dead_code)] Box<i32>, bool);
 
             impl Drop for Out {
                 fn drop(&mut self) {
@@ -71,7 +71,7 @@ macro_rules! schedule {
         static $sched: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -26,7 +26,7 @@ macro_rules! future {
         static $drop_t: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = Out;
@@ -44,7 +44,7 @@ macro_rules! future {
             }
 
             #[derive(Default)]
-            struct Out(Box<i32>, bool);
+            struct Out(#[allow(dead_code)] Box<i32>, bool);
 
             impl Drop for Out {
                 fn drop(&mut self) {
@@ -72,7 +72,7 @@ macro_rules! schedule {
         static $sched: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -23,7 +23,7 @@ macro_rules! future {
         static $drop: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = ();
@@ -59,7 +59,7 @@ macro_rules! schedule {
         static $sched: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/ready.rs
+++ b/tests/ready.rs
@@ -24,7 +24,7 @@ macro_rules! future {
         static $drop_t: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = Out;
@@ -43,7 +43,7 @@ macro_rules! future {
             }
 
             #[derive(Default)]
-            struct Out(Box<i32>, bool);
+            struct Out(#[allow(dead_code)] Box<i32>, bool);
 
             impl Drop for Out {
                 fn drop(&mut self) {
@@ -71,7 +71,7 @@ macro_rules! schedule {
         static $sched: AtomicUsize = AtomicUsize::new(0);
 
         let $name = {
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/waker_panic.rs
+++ b/tests/waker_panic.rs
@@ -29,7 +29,7 @@ macro_rules! future {
         static WAKER: AtomicWaker = AtomicWaker::new();
 
         let ($name, $get_waker) = {
-            struct Fut(Cell<bool>, Box<i32>);
+            struct Fut(Cell<bool>, #[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = ();
@@ -76,7 +76,7 @@ macro_rules! schedule {
         let ($name, $chan) = {
             let (s, r) = flume::unbounded();
 
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/waker_pending.rs
+++ b/tests/waker_pending.rs
@@ -26,7 +26,7 @@ macro_rules! future {
         static WAKER: AtomicWaker = AtomicWaker::new();
 
         let ($name, $get_waker) = {
-            struct Fut(Box<i32>);
+            struct Fut(#[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = ();
@@ -67,7 +67,7 @@ macro_rules! schedule {
         let ($name, $chan) = {
             let (s, r) = flume::unbounded();
 
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {

--- a/tests/waker_ready.rs
+++ b/tests/waker_ready.rs
@@ -26,7 +26,7 @@ macro_rules! future {
         static WAKER: AtomicWaker = AtomicWaker::new();
 
         let ($name, $get_waker) = {
-            struct Fut(Cell<bool>, Box<i32>);
+            struct Fut(Cell<bool>, #[allow(dead_code)] Box<i32>);
 
             impl Future for Fut {
                 type Output = Box<i32>;
@@ -73,7 +73,7 @@ macro_rules! schedule {
         let ($name, $chan) = {
             let (s, r) = flume::unbounded();
 
-            struct Guard(Box<i32>);
+            struct Guard(#[allow(dead_code)] Box<i32>);
 
             impl Drop for Guard {
                 fn drop(&mut self) {


### PR DESCRIPTION
- Fix CI failure https://github.com/smol-rs/async-task/actions/runs/7435537805/job/20230979144
- Migrate to Rust 2021
- Use cargo-hack's --rust-version flag for msrv check
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.