### PR TITLE
Always set #![no_std] to fix redundant import warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! vanishes and only reappears when its [`Waker`][`core::task::Waker`] wakes the task, thus
 //! scheduling it to be run again.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
@@ -79,6 +79,8 @@
 )]
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 /// We can't use `?` in const contexts yet, so this macro acts
 /// as a workaround.

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -420,7 +420,7 @@ impl<M> Builder<M> {
 
         #[inline]
         fn thread_id() -> ThreadId {
-            thread_local! {
+            std::thread_local! {
                 static ID: ThreadId = thread::current().id();
             }
             ID.try_with(|id| *id)


### PR DESCRIPTION
```
error: the item `Box` is imported redundantly
 --> src/runnable.rs:9:5
  |
9 | use alloc::boxed::Box;
  |     ^^^^^^^^^^^^^^^^^
 --> /rustc/5119208fd78a77547c705d1695428c88d6791263/library/std/src/prelude/mod.rs:125:13
  |
  = note: the item `Box` is already defined here
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`
```