### PR TITLE
ci: Use reusable workflows for fmt and security_audit & fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Run cargo test (with valgrind)
         run: cargo test -- --test-threads=1
         env:
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=all --track-origins=yes --fair-sched=yes
+          # TODO: use --errors-for-leak-kinds=definite,indirect due to upstream bug (https://github.com/rust-lang/rust/issues/135608)
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --track-origins=yes --fair-sched=yes
       - name: Run cargo test (with portable-atomic enabled)
         run: cargo test --features portable-atomic
       - name: Clone async-executor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -78,14 +88,6 @@ jobs:
         run: rustup update stable
       - run: cargo clippy --all-features --tests --examples
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -98,19 +100,3 @@ jobs:
           # disable preemption due to https://github.com/rust-lang/rust/issues/55005
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/with-metadata.rs
+++ b/examples/with-metadata.rs
@@ -49,7 +49,7 @@ pin_project! {
     }
 }
 
-impl<'a, F: Future> Future for MeasureRuntime<'a, F> {
+impl<F: Future> Future for MeasureRuntime<'_, F> {
     type Output = F::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -829,7 +829,7 @@ impl<M> Runnable<M> {
     ///
     /// ```rust
     /// use async_task::{Runnable, spawn};
-
+    ///
     /// let (runnable, task) = spawn(async {}, |_| {});
     /// let runnable_pointer = runnable.into_raw();
     ///
@@ -866,7 +866,7 @@ impl<M> Runnable<M> {
     ///
     /// ```rust
     /// use async_task::{Runnable, spawn};
-
+    ///
     /// let (runnable, task) = spawn(async {}, |_| {});
     /// let runnable_pointer = runnable.into_raw();
     ///
@@ -880,7 +880,7 @@ impl<M> Runnable<M> {
     /// }
     /// // The memory was freed when `x` went out of scope above, so `runnable_pointer` is now dangling!
     /// ```
-
+    ///
     /// [into_raw]: #method.into_raw
     pub unsafe fn from_raw(ptr: NonNull<()>) -> Self {
         Self {


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
See the second to fourth commits for CI failure.
