### PR TITLE
Avoid boxing large futures

### DIFF
--- a/examples/with-metadata.rs
+++ b/examples/with-metadata.rs
@@ -72,9 +72,7 @@ thread_local! {
     static QUEUE: RefCell<BinaryHeap<ByDuration>> = RefCell::new(BinaryHeap::new());
 }
 
-fn make_future_fn<'a, F>(
-    future: F,
-) -> impl (FnOnce(&'a DurationMetadata) -> MeasureRuntime<'a, F>) {
+fn make_future_fn<'a, F>(future: F) -> impl FnOnce(&'a DurationMetadata) -> MeasureRuntime<'a, F> {
     move |duration_meta| MeasureRuntime {
         f: future,
         duration: &duration_meta.inner,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -204,7 +204,7 @@ where
             (raw.schedule as *mut S).write(schedule);
 
             // Explicitly avoid using abort_on_panic here to avoid extra stack
-            // copies of the future.
+            // copies of the future on lower optimization levels.
             let bomb = Bomb;
 
             // Generate the future, now that the metadata has been pinned in place.

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -275,21 +275,19 @@ impl Builder<()> {
     }
 }
 
-// Use a macro to brute force inlining to minimize stack copies of potentially 
+// Use a macro to brute force inlining to minimize stack copies of potentially
 // large futures.
 macro_rules! spawn_unchecked {
-    ($meta:tt, $future:ident, $schedule:ident, $builder:ident) => {
-        {
-            let ptr = RawTask::<_, _, S, $meta>::allocate($future, $schedule, $builder);
+    ($meta:tt, $future:ident, $schedule:ident, $builder:ident) => {{
+        let ptr = RawTask::<_, _, S, $meta>::allocate($future, $schedule, $builder);
 
-            let runnable = unsafe { Runnable::from_raw(ptr) };
-            let task = Task {
-                ptr,
-                _marker: PhantomData,
-            };
-            (runnable, task)
-        }
-    };
+        let runnable = unsafe { Runnable::from_raw(ptr) };
+        let task = Task {
+            ptr,
+            _marker: PhantomData,
+        };
+        (runnable, task)
+    }};
 }
 
 impl<M> Builder<M> {

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -6,8 +6,6 @@ use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use core::task::Waker;
 
-use alloc::boxed::Box;
-
 use crate::header::Header;
 use crate::raw::RawTask;
 use crate::state::*;

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -652,7 +652,7 @@ where
     S: Schedule,
 {
     let builder = Builder::new();
-    unsafe { spawn_unchecked!(F, S, (), builder, schedule, raw => { future }) }
+    spawn_unchecked!(F, S, (), builder, schedule, raw => { future })
 }
 
 /// A handle to a runnable task.

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -281,10 +281,7 @@ macro_rules! spawn_unchecked {
     ($meta:tt, $future:ident, $schedule:ident, $builder:ident) => {{
         let ptr = RawTask::<_, _, S, $meta>::allocate($future, $schedule, $builder);
 
-        #[allow(
-            unused_unsafe,
-            reason = "This macro might be used in unsafe functions or blocks."
-        )]
+        #[allow(unused_unsafe)]
         // SAFTETY: The task was just allocated above.
         let runnable = unsafe { Runnable::from_raw(ptr) };
         let task = Task {

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -281,6 +281,11 @@ macro_rules! spawn_unchecked {
     ($meta:tt, $future:ident, $schedule:ident, $builder:ident) => {{
         let ptr = RawTask::<_, _, S, $meta>::allocate($future, $schedule, $builder);
 
+        #[allow(
+            unused_unsafe,
+            reason = "This macro might be used in unsafe functions or blocks."
+        )]
+        // SAFTETY: The task was just allocated above.
         let runnable = unsafe { Runnable::from_raw(ptr) };
         let task = Task {
             ptr,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,19 +17,19 @@ pub(crate) fn abort() -> ! {
     panic!("aborting the process");
 }
 
+pub(crate) struct Bomb;
+
+impl Drop for Bomb {
+    fn drop(&mut self) {
+        abort();
+    }
+}
+
 /// Calls a function and aborts if it panics.
 ///
 /// This is useful in unsafe code where we can't recover from panics.
 #[inline]
 pub(crate) fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
-    struct Bomb;
-
-    impl Drop for Bomb {
-        fn drop(&mut self) {
-            abort();
-        }
-    }
-
     let bomb = Bomb;
     let t = f();
     mem::forget(bomb);


### PR DESCRIPTION
Fixes #83. Fixes #66. Partially fixes #78.

This PR gets rid of the extra boxing in `spawn_unchecked` that results in extra monomorphization and overhead of allocating and moving into a `Pin<Box<Fut>>`.  The boxing causes an extra copy onto the stack before moving onto the heap. This negates only one of the two stack copies made on lower optimization builds, and requires an extra indirection on every access, so we get rid of it.

Instead, this PR turns `spawn_unchecked` into a macro to avoid creating extra stack frames, effectively forcibly inlining the code regardless of what optimization level. This PR also opts to replace the `abort_on_panic` implementation with a manual one to avoid the extra stack copy there.