### PR TITLE
Require non-closure schedule functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Run cargo test (with valgrind)
         run: cargo test -- --test-threads=1
         env:
-          # TODO: use --errors-for-leak-kinds=definite,indirect due to upstream bug (https://github.com/rust-lang/rust/issues/135608)
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --track-origins=yes --fair-sched=yes
+          # TODO: ignore possible and reachable leaks due to upstream issue (https://github.com/rust-lang/rust/issues/135608)
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=definite,indirect --errors-for-leak-kinds=definite,indirect --track-origins=yes --fair-sched=yes --gen-suppressions=all
       - name: Run cargo test (with portable-atomic enabled)
         run: cargo test --features portable-atomic
       - name: Clone async-executor

--- a/examples/with-metadata.rs
+++ b/examples/with-metadata.rs
@@ -72,9 +72,7 @@ thread_local! {
     static QUEUE: RefCell<BinaryHeap<ByDuration>> = RefCell::new(BinaryHeap::new());
 }
 
-fn make_future_fn<'a, F>(
-    future: F,
-) -> impl (FnOnce(&'a DurationMetadata) -> MeasureRuntime<'a, F>) {
+fn make_future_fn<'a, F>(future: F) -> impl FnOnce(&'a DurationMetadata) -> MeasureRuntime<'a, F> {
     move |duration_meta| MeasureRuntime {
         f: future,
         duration: &duration_meta.inner,

--- a/src/header.rs
+++ b/src/header.rs
@@ -9,7 +9,7 @@ use core::sync::atomic::Ordering;
 use portable_atomic::AtomicUsize;
 
 use crate::raw::TaskVTable;
-use crate::state::*;
+use crate::{state::*, Runnable, ScheduleInfo};
 use crate::utils::abort_on_panic;
 
 /// The header of a task.
@@ -31,6 +31,8 @@ pub(crate) struct Header<M> {
     /// In addition to the actual waker virtual table, it also contains pointers to several other
     /// methods necessary for bookkeeping the heap-allocated task.
     pub(crate) vtable: &'static TaskVTable,
+
+    pub(crate) schedule: fn(Runnable<M>, ScheduleInfo),
 
     /// Metadata associated with the task.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 #![no_std]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
-#![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
+#![doc(test(attr(allow(unused_variables))))]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@
 //!
 //! // Push the task into the queue by invoking its schedule function.
 //! runnable.schedule();
+//! # let handle = std::thread::spawn(move || { for runnable in receiver { runnable.run(); }});
+//! # smol::future::block_on(task);
+//! # handle.join().unwrap();
 //! ```
 //!
 //! The [`Runnable`] is used to poll the task's future, and the [`Task`] is used to await its

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,6 @@ mod task;
 mod utils;
 
 pub use crate::runnable::{
-    spawn, spawn_unchecked, Builder, Runnable, Schedule, ScheduleInfo, WithInfo,
+    Builder, Runnable, ScheduleInfo,
 };
 pub use crate::task::{FallibleTask, Task};
-
-#[cfg(feature = "std")]
-pub use crate::runnable::spawn_local;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,16 +1,11 @@
 use alloc::alloc::Layout as StdLayout;
-use core::cell::UnsafeCell;
 use core::future::Future;
 use core::mem::{self, ManuallyDrop};
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
-#[cfg(feature = "portable-atomic")]
-use portable_atomic::AtomicUsize;
 
 use crate::header::Header;
 use crate::runnable::{Schedule, ScheduleInfo};
@@ -99,7 +94,7 @@ impl<F, T, S, M> Clone for RawTask<F, T, S, M> {
 }
 
 impl<F, T, S, M> RawTask<F, T, S, M> {
-    const TASK_LAYOUT: TaskLayout = Self::eval_task_layout();
+    pub(crate) const TASK_LAYOUT: TaskLayout = Self::eval_task_layout();
 
     /// Computes the memory layout for a task.
     #[inline]
@@ -131,81 +126,81 @@ impl<F, T, S, M> RawTask<F, T, S, M> {
     }
 }
 
+/// Allocates a task with the given `future` and `schedule` function.
+///
+/// It is assumed that initially only the `Runnable` and the `Task` exist.
+///
+/// Use a macro to brute force inlining to minimize stack copies of potentially
+/// large futures.
+macro_rules! allocate_task {
+    ($f:tt, $s:tt, $m:tt, $builder:ident, $schedule:ident, $raw:ident => $future:block) => {{
+        let allocation =
+            alloc::alloc::alloc(RawTask::<$f, <$f as Future>::Output, $s, $m>::TASK_LAYOUT.layout);
+        // Allocate enough space for the entire task.
+        let ptr = NonNull::new(allocation as *mut ()).unwrap_or_else(|| crate::utils::abort());
+
+        let $raw = RawTask::<$f, <$f as Future>::Output, $s, $m>::from_ptr(ptr.as_ptr());
+
+        let crate::Builder {
+            metadata,
+            #[cfg(feature = "std")]
+            propagate_panic,
+        } = $builder;
+
+        // Write the header as the first field of the task.
+        ($raw.header as *mut Header<$m>).write(Header {
+            #[cfg(not(feature = "portable-atomic"))]
+            state: core::sync::atomic::AtomicUsize::new(SCHEDULED | TASK | REFERENCE),
+            #[cfg(feature = "portable-atomic")]
+            state: portable_atomic::AtomicUsize::new(SCHEDULED | TASK | REFERENCE),
+            awaiter: core::cell::UnsafeCell::new(None),
+            vtable: &RawTask::<$f, <$f as Future>::Output, $s, $m>::TASK_VTABLE,
+            metadata,
+            #[cfg(feature = "std")]
+            propagate_panic,
+        });
+
+        // Write the schedule function as the third field of the task.
+        ($raw.schedule as *mut S).write($schedule);
+
+        // Explicitly avoid using abort_on_panic here to avoid extra stack
+        // copies of the future on lower optimization levels.
+        let bomb = crate::utils::Bomb;
+
+        // Generate the future, now that the metadata has been pinned in place.
+        // Write the future as the fourth field of the task.
+        $raw.future.write($future);
+        // (&(*raw.header).metadata)
+
+        mem::forget(bomb);
+        ptr
+    }};
+}
+
+pub(crate) use allocate_task;
+
 impl<F, T, S, M> RawTask<F, T, S, M>
 where
     F: Future<Output = T>,
     S: Schedule<M>,
 {
-    const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
+    pub(crate) const RAW_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
         Self::clone_waker,
         Self::wake,
         Self::wake_by_ref,
         Self::drop_waker,
     );
 
-    /// Allocates a task with the given `future` and `schedule` function.
-    ///
-    /// It is assumed that initially only the `Runnable` and the `Task` exist.
-    pub(crate) fn allocate<'a, Gen: FnOnce(&'a M) -> F>(
-        future: Gen,
-        schedule: S,
-        builder: crate::Builder<M>,
-    ) -> NonNull<()>
-    where
-        F: 'a,
-        M: 'a,
-    {
-        // Compute the layout of the task for allocation. Abort if the computation fails.
-        //
-        // n.b. notgull: task_layout now automatically aborts instead of panicking
-        let task_layout = Self::task_layout();
-
-        unsafe {
-            // Allocate enough space for the entire task.
-            let ptr = match NonNull::new(alloc::alloc::alloc(task_layout.layout) as *mut ()) {
-                None => abort(),
-                Some(p) => p,
-            };
-
-            let raw = Self::from_ptr(ptr.as_ptr());
-
-            let crate::Builder {
-                metadata,
-                #[cfg(feature = "std")]
-                propagate_panic,
-            } = builder;
-
-            // Write the header as the first field of the task.
-            (raw.header as *mut Header<M>).write(Header {
-                state: AtomicUsize::new(SCHEDULED | TASK | REFERENCE),
-                awaiter: UnsafeCell::new(None),
-                vtable: &TaskVTable {
-                    schedule: Self::schedule,
-                    drop_future: Self::drop_future,
-                    get_output: Self::get_output,
-                    drop_ref: Self::drop_ref,
-                    destroy: Self::destroy,
-                    run: Self::run,
-                    clone_waker: Self::clone_waker,
-                    layout_info: &Self::TASK_LAYOUT,
-                },
-                metadata,
-                #[cfg(feature = "std")]
-                propagate_panic,
-            });
-
-            // Write the schedule function as the third field of the task.
-            (raw.schedule as *mut S).write(schedule);
-
-            // Generate the future, now that the metadata has been pinned in place.
-            let future = abort_on_panic(|| future(&(*raw.header).metadata));
-
-            // Write the future as the fourth field of the task.
-            raw.future.write(future);
-
-            ptr
-        }
-    }
+    pub(crate) const TASK_VTABLE: TaskVTable = TaskVTable {
+        schedule: Self::schedule,
+        drop_future: Self::drop_future,
+        get_output: Self::get_output,
+        drop_ref: Self::drop_ref,
+        destroy: Self::destroy,
+        run: Self::run,
+        clone_waker: Self::clone_waker,
+        layout_info: &Self::TASK_LAYOUT,
+    };
 
     /// Creates a `RawTask` from a raw task pointer.
     #[inline]

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -7,6 +7,8 @@ use core::sync::atomic::Ordering;
 use core::task::Waker;
 
 use crate::header::Header;
+use crate::header::HeaderWithMetadata;
+use crate::raw::drop_ref;
 use crate::raw::{allocate_task, RawTask};
 use crate::state::*;
 use crate::Task;
@@ -715,7 +717,7 @@ impl<M> Runnable<M> {
     /// Tasks can be created with a metadata object associated with them; by default, this
     /// is a `()` value. See the [`Builder::metadata()`] method for more information.
     pub fn metadata(&self) -> &M {
-        &self.header().metadata
+        &self.header_with_metadata().metadata
     }
 
     /// Schedules the task.
@@ -742,7 +744,7 @@ impl<M> Runnable<M> {
     /// ```
     pub fn schedule(self) {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header<M>;
+        let header = ptr as *const Header;
         mem::forget(self);
 
         unsafe {
@@ -780,7 +782,7 @@ impl<M> Runnable<M> {
     /// ```
     pub fn run(self) -> bool {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header<M>;
+        let header = ptr as *const Header;
         mem::forget(self);
 
         unsafe { ((*header).vtable.run)(ptr) }
@@ -813,17 +815,18 @@ impl<M> Runnable<M> {
     /// # handle.join().unwrap();
     /// ```
     pub fn waker(&self) -> Waker {
-        let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header<M>;
-
         unsafe {
-            let raw_waker = ((*header).vtable.clone_waker)(ptr);
+            let raw_waker = Header::clone_waker(self.ptr.as_ptr());
             Waker::from_raw(raw_waker)
         }
     }
 
-    fn header(&self) -> &Header<M> {
-        unsafe { &*(self.ptr.as_ptr() as *const Header<M>) }
+    fn header(&self) -> &Header {
+        unsafe { &*(self.ptr.as_ptr() as *const Header) }
+    }
+
+    fn header_with_metadata(&self) -> &HeaderWithMetadata<M> {
+        unsafe { &*(self.ptr.as_ptr() as *const HeaderWithMetadata<M>) }
     }
 
     /// Converts this task into a raw pointer.
@@ -925,7 +928,7 @@ impl<M> Drop for Runnable<M> {
             }
 
             // Drop the future.
-            (header.vtable.drop_future)(ptr);
+            (header.vtable.drop_future)(ptr, header.vtable.layout_info);
 
             // Mark the task as unscheduled.
             let state = header.state.fetch_and(!SCHEDULED, Ordering::AcqRel);
@@ -936,7 +939,7 @@ impl<M> Drop for Runnable<M> {
             }
 
             // Drop the task reference.
-            (header.vtable.drop_ref)(ptr);
+            drop_ref(ptr);
         }
     }
 }
@@ -944,7 +947,7 @@ impl<M> Drop for Runnable<M> {
 impl<M: fmt::Debug> fmt::Debug for Runnable<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let ptr = self.ptr.as_ptr();
-        let header = ptr as *const Header<M>;
+        let header = ptr as *const HeaderWithMetadata<M>;
 
         f.debug_struct("Runnable")
             .field("header", unsafe { &(*header) })

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -734,6 +734,9 @@ impl<M> Runnable<M> {
     /// assert_eq!(r.len(), 0);
     /// runnable.schedule();
     /// assert_eq!(r.len(), 1);
+    /// # let handle = std::thread::spawn(move || { for runnable in r { runnable.run(); }});
+    /// # smol::future::block_on(task);
+    /// # handle.join().unwrap();
     /// ```
     pub fn schedule(self) {
         let ptr = self.ptr.as_ptr();
@@ -803,6 +806,9 @@ impl<M> Runnable<M> {
     /// assert_eq!(r.len(), 0);
     /// waker.wake();
     /// assert_eq!(r.len(), 1);
+    /// # let handle = std::thread::spawn(move || { for runnable in r { runnable.run(); }});
+    /// # smol::future::block_on(task.cancel()); // cancel because the future is future::pending
+    /// # handle.join().unwrap();
     /// ```
     pub fn waker(&self) -> Waker {
         let ptr = self.ptr.as_ptr();

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,7 +55,7 @@ pub(crate) const REGISTERING: usize = 1 << 6;
 /// Set if the awaiter is being notified.
 ///
 /// This flag is set when notifying the awaiter. If an awaiter is concurrently registered and
-/// notified, whichever side came first will take over the reposibility of resolving the race.
+/// notified, whichever side came first will take over the responsibility of resolving the race.
 pub(crate) const NOTIFYING: usize = 1 << 7;
 
 /// A single reference.

--- a/src/task.rs
+++ b/src/task.rs
@@ -237,7 +237,7 @@ impl<T, M> Task<T, M> {
             let mut output = None;
 
             // Optimistically assume the `Task` is being detached just after creating the task.
-            // This is a common case so if the `Task` is datached, the overhead of it is only one
+            // This is a common case so if the `Task` is detached, the overhead of it is only one
             // compare-exchange operation.
             if let Err(mut state) = (*header).state.compare_exchange_weak(
                 SCHEDULED | TASK | REFERENCE,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,19 +17,19 @@ pub(crate) fn abort() -> ! {
     panic!("aborting the process");
 }
 
+pub(crate) struct Bomb;
+
+impl Drop for Bomb {
+    fn drop(&mut self) {
+        abort();
+    }
+}
+
 /// Calls a function and aborts if it panics.
 ///
 /// This is useful in unsafe code where we can't recover from panics.
 #[inline]
 pub(crate) fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
-    struct Bomb;
-
-    impl Drop for Bomb {
-        fn drop(&mut self) {
-            abort();
-        }
-    }
-
     let bomb = Bomb;
     let t = f();
     mem::forget(bomb);


### PR DESCRIPTION
Addresses https://github.com/smol-rs/async-executor/pull/149 at this crates' level. This removes the `Schedule` trait and requires a direct function pointer as a scheduling function. This is a usability regression, but it avoids the extra performance cost on all re-schedules. As an alternative to captured variables, a Task can instead embed the required scheduling information inside it's metadata.

This is a major breaking change and will require a major version bump on release.