### PR TITLE
Fix typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ once_cell = "1"
 pin-project-lite = "0.2.10"
 smol = "2"
 
-# rewrite dependencies to use the this version of async-task when running tests
+# rewrite dependencies to use this version of async-task when running tests
 [patch.crates-io]
 async-task = { path = "." }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ let (sender, receiver) = flume::unbounded();
 ```
 
 A task is created using either `spawn()`, `spawn_local()`, or `spawn_unchecked()` which
-return a `Runnable` and a `Task`:
+returns a `Runnable` and a `Task`:
 
 ```rust
 // A future that will be spawned.

--- a/src/header.rs
+++ b/src/header.rs
@@ -15,7 +15,7 @@ use crate::utils::abort_on_panic;
 
 /// Actions to take upon calling [`Header::drop_waker`].
 pub(crate) enum DropWakerAction {
-    /// Re-schedule the task
+    /// Re-schedule the task.
     Schedule,
     /// Destroy the task.
     Destroy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```
 //!
 //! A task is created using either [`spawn()`], [`spawn_local()`], or [`spawn_unchecked()`] which
-//! return a [`Runnable`] and a [`Task`]:
+//! returns a [`Runnable`] and a [`Task`]:
 //!
 //! ```
 //! # let (sender, receiver) = flume::unbounded();

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -110,7 +110,7 @@ impl<F, T, S, M> RawTask<F, T, S, M> {
         let align_union = max(layout_f.align(), layout_r.align());
         let layout_union = Layout::from_size_align(size_union, align_union);
 
-        // Compute the layout for `Header` followed `S` and `union { F, T }`.
+        // Compute the layout for `Header` followed by `S` and `union { F, T }`.
         let layout = layout_header;
         let (layout, offset_s) = leap_unwrap!(layout.extend(layout_s));
         let (layout, offset_union) = leap_unwrap!(layout.extend(layout_union));


### PR DESCRIPTION
Typos found while reading documentation.

Shout out to https://github.com/stoeckmann/lets-read-oss