### PR TITLE
Add custom allocator support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     uses: smol-rs/.github/.github/workflows/clippy.yml@main
     with:
       bench: false # We run clippy using stable rustc, but our benchmarks use #![feature(test)].
+      # features: 'std,portable-atomic,allocator-api2' # TODO: Action needs to support a new input to exclude nightly features.
   security_audit:
     uses: smol-rs/.github/.github/workflows/security_audit.yml@main
     permissions:
@@ -68,6 +69,11 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind -v --error-exitcode=1 --error-limit=no --leak-check=full --show-leak-kinds=definite,indirect --errors-for-leak-kinds=definite,indirect --track-origins=yes --fair-sched=yes --gen-suppressions=all
       - name: Run cargo test (with portable-atomic enabled)
         run: cargo test --features portable-atomic
+      - name: Run cargo test (with allocator-api2 enabled)
+        run: cargo test --features allocator-api2
+      - name: Run cargo test (with nightly allocator_api enabled)
+        run: cargo test --features allocator_api
+        if: startsWith(matrix.rust, 'nightly')
       - name: Clone async-executor
         run: git clone https://github.com/smol-rs/async-executor.git
       - name: Add patch section

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous", "concurrency", "no-std"]
 exclude = ["/.*"]
 
 [features]
-default = ["std", "allocator-api2"]
+default = ["std"]
 allocator_api = []
 std = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = ["/.*"]
 [features]
 default = ["std", "allocator-api2"]
 allocator_api = []
-allocator-api2 = ["dep:allocator-api2"]
 std = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,20 @@ categories = ["asynchronous", "concurrency", "no-std"]
 exclude = ["/.*"]
 
 [features]
-default = ["std"]
+default = ["std", "allocator-api2"]
+allocator_api = []
+allocator-api2 = ["dep:allocator-api2"]
 std = []
 
 [dependencies]
 # Uses portable-atomic polyfill atomics on targets without them
 portable-atomic = { version = "1", optional = true, default-features = false }
+
+[dependencies.allocator-api2]
+version = "0.3.1"
+optional = true
+default-features = false
+features = ["alloc"]
 
 [dev-dependencies]
 atomic-waker = "1"

--- a/src/alloc_api.rs
+++ b/src/alloc_api.rs
@@ -1,0 +1,106 @@
+pub(crate) use self::inner::{allocate, deallocate, Allocator, Global};
+
+// Nightly `allocator_api` feature case.
+#[cfg(feature = "allocator_api")]
+mod inner {
+    pub use crate::alloc::alloc::{Allocator, Global};
+
+    use crate::alloc::alloc::Layout;
+    use core::ptr::NonNull;
+
+    pub(crate) fn allocate<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        match alloc.allocate(layout) {
+            Ok(ptr) => Ok(ptr.cast()),
+            Err(_) => Err(()),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - `ptr` must have been allocated by `alloc` using the same allocator.
+    /// - `layout` must be the same layout that was used to allocate `ptr`.
+    /// - `ptr` must not be used after this call.
+    pub(crate) unsafe fn deallocate<A: Allocator>(alloc: &A, ptr: *mut u8, layout: Layout) {
+        alloc.deallocate(NonNull::new_unchecked(ptr), layout)
+    }
+}
+
+// Non-nightly `allocator-api2` feature case.
+#[cfg(all(feature = "allocator-api2", not(feature = "allocator_api")))]
+mod inner {
+    pub use allocator_api2::alloc::{Allocator, Global};
+
+    use crate::alloc::alloc::Layout;
+    use core::ptr::NonNull;
+
+    pub(crate) fn allocate<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        match alloc.allocate(layout) {
+            Ok(ptr) => Ok(ptr.cast()),
+            Err(_) => Err(()),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - `ptr` must have been allocated by `alloc` using the same allocator.
+    /// - `layout` must be the same layout that was used to allocate `ptr`.
+    /// - `ptr` must not be used after this call.
+    pub(crate) unsafe fn deallocate<A: Allocator>(alloc: &A, ptr: *mut u8, layout: Layout) {
+        alloc.deallocate(NonNull::new_unchecked(ptr), layout)
+    }
+}
+
+// Default case without allocator api.
+#[cfg(not(any(feature = "allocator_api", feature = "allocator-api2")))]
+mod inner {
+    use crate::alloc::alloc::{alloc, dealloc, Layout};
+    use core::ptr::NonNull;
+
+    /// # Safety
+    ///
+    /// Used only within the crate and implemented only for [`Global`].
+    pub unsafe trait Allocator {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()>;
+
+        /// # Safety
+        ///
+        /// - `ptr` must have been returned by a previous call to `allocate` on this allocator.
+        /// - `layout` must be the same layout used in that `allocate` call.
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct Global;
+
+    impl Default for Global {
+        #[inline]
+        fn default() -> Self {
+            Global
+        }
+    }
+
+    unsafe impl Allocator for Global {
+        #[inline]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()> {
+            unsafe { NonNull::new(alloc(layout)).ok_or(()) }
+        }
+
+        #[inline]
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            dealloc(ptr.as_ptr(), layout);
+        }
+    }
+
+    pub(crate) fn allocate<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        alloc.allocate(layout)
+    }
+
+    /// # Safety
+    ///
+    /// - `ptr` must have been allocated by `alloc` using the same allocator.
+    /// - `layout` must be the same layout that was used to allocate `ptr`.
+    /// - `ptr` must not be used after this call.
+    pub(crate) unsafe fn deallocate<A: Allocator>(alloc: &A, ptr: *mut u8, layout: Layout) {
+        alloc.deallocate(NonNull::new_unchecked(ptr), layout)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 extern crate alloc;
 #[cfg(feature = "std")]
@@ -105,6 +106,7 @@ macro_rules! leap_unwrap {
     }};
 }
 
+mod alloc_api;
 mod header;
 mod raw;
 mod runnable;
@@ -117,5 +119,14 @@ pub use crate::runnable::{
 };
 pub use crate::task::{FallibleTask, Task};
 
+#[cfg(any(feature = "allocator_api", feature = "allocator-api2"))]
+pub use crate::runnable::{spawn_in, spawn_unchecked_in};
+
 #[cfg(feature = "std")]
 pub use crate::runnable::spawn_local;
+
+#[cfg(all(
+    feature = "std",
+    any(feature = "allocator_api", feature = "allocator-api2")
+))]
+pub use crate::runnable::spawn_local_in;

--- a/tests/custom_allocator.rs
+++ b/tests/custom_allocator.rs
@@ -1,0 +1,305 @@
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
+#![cfg(any(feature = "allocator_api", feature = "allocator-api2"))]
+
+use std::future::Future;
+use std::panic::catch_unwind;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+use std::thread;
+use std::time::Duration;
+
+use async_task::Runnable;
+use easy_parallel::Parallel;
+
+#[cfg(feature = "allocator_api")]
+extern crate alloc;
+#[cfg(feature = "allocator_api")]
+pub use alloc::alloc::{AllocError, Allocator, Global};
+
+#[cfg(all(feature = "allocator-api2", not(feature = "allocator_api")))]
+pub use allocator_api2::alloc::{AllocError, Allocator, Global};
+
+// Creates a future with event counters.
+//
+// Usage: `future!(f, POLL, DROP)`
+//
+// The future `f` always returns `Poll::Ready`.
+// When it gets polled, `POLL` is incremented.
+// When it gets dropped, `DROP` is incremented.
+macro_rules! future {
+    ($name:pat, $poll:ident, $drop:ident) => {
+        static $poll: AtomicUsize = AtomicUsize::new(0);
+        static $drop: AtomicUsize = AtomicUsize::new(0);
+
+        let $name = {
+            struct Fut(#[allow(dead_code)] Box<i32>);
+
+            impl Future for Fut {
+                type Output = Box<i32>;
+
+                fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+                    $poll.fetch_add(1, Ordering::SeqCst);
+                    Poll::Ready(Box::new(42))
+                }
+            }
+
+            impl Drop for Fut {
+                fn drop(&mut self) {
+                    $drop.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            Fut(Box::new(0))
+        };
+    };
+}
+
+// Creates a future with event counters.
+//
+// Usage: `panic_future!(f, POLL, DROP)`
+//
+// The future `f` sleeps for 400 ms and then panics.
+// When it gets polled, `POLL` is incremented.
+// When it gets dropped, `DROP` is incremented.
+macro_rules! panic_future {
+    ($name:pat, $poll:ident, $drop:ident) => {
+        static $poll: AtomicUsize = AtomicUsize::new(0);
+        static $drop: AtomicUsize = AtomicUsize::new(0);
+
+        let $name = {
+            struct Fut(#[allow(dead_code)] Box<i32>);
+
+            impl Future for Fut {
+                type Output = ();
+
+                fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+                    $poll.fetch_add(1, Ordering::SeqCst);
+                    thread::sleep(Duration::from_millis(400));
+                    panic!()
+                }
+            }
+
+            impl Drop for Fut {
+                fn drop(&mut self) {
+                    $drop.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            Fut(Box::new(0))
+        };
+    };
+}
+
+// Creates a schedule function with event counters.
+//
+// Usage: `schedule!(s, SCHED, DROP)`
+//
+// The schedule function `s` does nothing.
+// When it gets invoked, `SCHED` is incremented.
+// When it gets dropped, `DROP` is incremented.
+macro_rules! schedule {
+    ($name:pat, $sched:ident, $drop:ident) => {
+        static $drop: AtomicUsize = AtomicUsize::new(0);
+        static $sched: AtomicUsize = AtomicUsize::new(0);
+
+        let $name = {
+            struct Guard(#[allow(dead_code)] Box<i32>);
+
+            impl Drop for Guard {
+                fn drop(&mut self) {
+                    $drop.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            let guard = Guard(Box::new(0));
+            move |_runnable: Runnable| {
+                let _ = &guard;
+                $sched.fetch_add(1, Ordering::SeqCst);
+            }
+        };
+    };
+}
+
+// Creates an allocator with event counters.
+//
+// Usage: `allocator!(a, ALLOC, DEALLOC, DROP)`
+//
+// The allocator `a` wraps `Global` and tracks allocations.
+// When `allocate` is called, `ALLOC` is incremented.
+// When `deallocate` is called, `DEALLOC` is incremented.
+// When it gets dropped, `DROP` is incremented.
+macro_rules! allocator {
+    ($name:pat, $alloc:ident, $dealloc:ident, $drop:ident) => {
+        static $alloc: AtomicUsize = AtomicUsize::new(0);
+        static $dealloc: AtomicUsize = AtomicUsize::new(0);
+        static $drop: AtomicUsize = AtomicUsize::new(0);
+
+        let $name = {
+            struct TrackedAllocator(#[allow(dead_code)] Box<i32>);
+
+            unsafe impl Send for TrackedAllocator {}
+            unsafe impl Sync for TrackedAllocator {}
+
+            impl Drop for TrackedAllocator {
+                fn drop(&mut self) {
+                    $drop.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            unsafe impl Allocator for TrackedAllocator {
+                fn allocate(
+                    &self,
+                    layout: std::alloc::Layout,
+                ) -> Result<std::ptr::NonNull<[u8]>, AllocError> {
+                    $alloc.fetch_add(1, Ordering::SeqCst);
+                    Global.allocate(layout)
+                }
+
+                unsafe fn deallocate(
+                    &self,
+                    ptr: std::ptr::NonNull<u8>,
+                    layout: std::alloc::Layout,
+                ) {
+                    $dealloc.fetch_add(1, Ordering::SeqCst);
+                    Global.deallocate(ptr, layout)
+                }
+            }
+
+            TrackedAllocator(Box::new(0))
+        };
+    };
+}
+
+#[test]
+fn detach_and_drop() {
+    future!(f, POLL, DROP_F);
+    schedule!(s, SCHEDULE, DROP_S);
+    allocator!(a, ALLOC, DEALLOC, DROP_A);
+    let (runnable, task) = async_task::spawn_in(f, s, a);
+
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    task.detach();
+    assert_eq!(POLL.load(Ordering::SeqCst), 0);
+    assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 0);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    drop(runnable);
+    assert_eq!(POLL.load(Ordering::SeqCst), 0);
+    assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 1);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn cancel_and_run() {
+    future!(f, POLL, DROP_F);
+    schedule!(s, SCHEDULE, DROP_S);
+    allocator!(a, ALLOC, DEALLOC, DROP_A);
+    let (runnable, task) = async_task::spawn_in(f, s, a);
+
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    drop(task);
+    assert_eq!(POLL.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 0);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    runnable.run();
+    assert_eq!(POLL.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 1);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn run_and_cancel() {
+    future!(f, POLL, DROP_F);
+    schedule!(s, SCHEDULE, DROP_S);
+    allocator!(a, ALLOC, DEALLOC, DROP_A);
+    let (runnable, task) = async_task::spawn_in(f, s, a);
+
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    assert_eq!(POLL.load(Ordering::SeqCst), 0);
+    assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 0);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    runnable.run();
+    assert_eq!(POLL.load(Ordering::SeqCst), 1);
+    assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 0);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    drop(task);
+    assert_eq!(POLL.load(Ordering::SeqCst), 1);
+    assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_F.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_S.load(Ordering::SeqCst), 1);
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn cancel_during_run() {
+    panic_future!(f, POLL, DROP_F);
+    schedule!(s, SCHEDULE, DROP_S);
+    allocator!(a, ALLOC, DEALLOC, DROP_A);
+    let (runnable, task) = async_task::spawn_in(f, s, a);
+
+    assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+    assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+    assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+
+    Parallel::new()
+        .add(|| {
+            assert!(catch_unwind(|| runnable.run()).is_err());
+            assert_eq!(POLL.load(Ordering::SeqCst), 1);
+            assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+            assert_eq!(DROP_F.load(Ordering::SeqCst), 1);
+            assert_eq!(DROP_S.load(Ordering::SeqCst), 1);
+            assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+            assert_eq!(DEALLOC.load(Ordering::SeqCst), 1);
+            assert_eq!(DROP_A.load(Ordering::SeqCst), 1);
+        })
+        .add(|| {
+            thread::sleep(Duration::from_millis(200));
+
+            drop(task);
+            assert_eq!(POLL.load(Ordering::SeqCst), 1);
+            assert_eq!(SCHEDULE.load(Ordering::SeqCst), 0);
+            assert_eq!(DROP_F.load(Ordering::SeqCst), 0);
+            assert_eq!(DROP_S.load(Ordering::SeqCst), 0);
+            assert_eq!(ALLOC.load(Ordering::SeqCst), 1);
+            assert_eq!(DEALLOC.load(Ordering::SeqCst), 0);
+            assert_eq!(DROP_A.load(Ordering::SeqCst), 0);
+        })
+        .run();
+}

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -14,7 +14,7 @@ use smol::future;
 //
 // Usage: `future!(f, POLL, DROP)`
 //
-// The future `f` sleeps for 200 ms and then panics.
+// The future `f` sleeps for 400 ms and then panics.
 // When it gets polled, `POLL` is incremented.
 // When it gets dropped, `DROP` is incremented.
 macro_rules! future {


### PR DESCRIPTION
This adds support for custom allocators. Allows to control memory allocation for tasks by passing an allocator to new `spawn_in`, `spawn_local_in`, and `spawn_unchecked_in` functions and corresponding Builder methods hidden under the new feature flags.

It adds two different feature flags:

- Nightly allocator API via the `allocator_api` feature.
- Stable allocator API via the `allocator-api2` feature.

The allocator is stored inline with the task and dropped when the raw task is destroyed.

**Some concerns:**

I saw [this](https://github.com/smol-rs/async-task/issues/24) issue, and I understand the doubts about the API stability. However, I'd like to offer a few points to consider:

  - The `allocator-api2` crate is designed for stable Rust and is already used by major crates (hashbrown, bumpalo, etc.).
  - The `allocator_api` feature only works on nightly builds, which makes it self-explanatory that it's unstable and that the
  API may change in the future. Alternatively, we could support only `allocator-api2` and drop the nightly `allocator_api` feature entirely.

Additionally, these changes may require updates to some workflows, such as `smol-rs/.github/.github/workflows/clippy.yml`. If this PR is considered for merging, I'll make the required changes.

_I should mention that I'm not an expert in low-level Rust, so there may be areas in the unsafe code or memory management that could be improved. And even if this PR isn't the right fit for the crate given the instability of allocator API, I hope it can at least serve as a reference for anyone who wants to support custom allocators in their own forks._