### PR TITLE
Fix: Make Metadata Send to avoid unsound behavior

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,5 +1,6 @@
 use core::cell::UnsafeCell;
 use core::fmt;
+use core::mem::ManuallyDrop;
 use core::task::{RawWaker, Waker};
 
 #[cfg(not(feature = "portable-atomic"))]
@@ -217,7 +218,10 @@ pub(crate) struct HeaderWithMetadata<M> {
     /// Metadata associated with the task.
     ///
     /// This metadata may be provided to the user.
-    pub(crate) metadata: M,
+    ///
+    /// This metadata will always be manually dropped,
+    /// whenever `Runnable` and `Task` are both dropped.
+    pub(crate) metadata: ManuallyDrop<M>,
 }
 
 impl<M: fmt::Debug> fmt::Debug for HeaderWithMetadata<M> {

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -718,7 +718,10 @@ impl<M> Runnable<M> {
     ///
     /// Tasks can be created with a metadata object associated with them; by default, this
     /// is a `()` value. See the [`Builder::metadata()`] method for more information.
-    pub fn metadata(&self) -> &M {
+    pub fn metadata(&self) -> &M
+    where
+        M: Sync,
+    {
         &self.header_with_metadata().metadata
     }
 

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -8,7 +8,7 @@ use core::task::Waker;
 
 use crate::header::Header;
 use crate::header::HeaderWithMetadata;
-use crate::raw::drop_ref;
+use crate::raw::drop_runnable;
 use crate::raw::{allocate_task, RawTask};
 use crate::state::*;
 use crate::Task;
@@ -378,6 +378,7 @@ impl<M> Builder<M> {
     /// ```
     pub fn spawn<F, Fut, S>(self, future: F, schedule: S) -> (Runnable<M>, Task<Fut::Output, M>)
     where
+        M: Send + 'static,
         F: FnOnce(&M) -> Fut,
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
@@ -427,6 +428,7 @@ impl<M> Builder<M> {
         schedule: S,
     ) -> (Runnable<M>, Task<Fut::Output, M>)
     where
+        M: 'static,
         F: FnOnce(&M) -> Fut,
         Fut: Future + 'static,
         Fut::Output: 'static,
@@ -526,10 +528,10 @@ impl<M> Builder<M> {
         schedule: S,
     ) -> (Runnable<M>, Task<Fut::Output, M>)
     where
+        M: 'a,
         F: FnOnce(&'a M) -> Fut,
         Fut: Future + 'a,
         S: Schedule<M>,
-        M: 'a,
     {
         spawn_unchecked!(Fut, S, M, self, schedule, raw => { future(&(*raw.header).metadata) })
     }
@@ -703,8 +705,8 @@ pub struct Runnable<M = ()> {
     pub(crate) _marker: PhantomData<M>,
 }
 
-unsafe impl<M: Send + Sync> Send for Runnable<M> {}
-unsafe impl<M: Send + Sync> Sync for Runnable<M> {}
+unsafe impl<M> Send for Runnable<M> {}
+unsafe impl<M: Sync> Sync for Runnable<M> {}
 
 #[cfg(feature = "std")]
 impl<M> std::panic::UnwindSafe for Runnable<M> {}
@@ -938,8 +940,7 @@ impl<M> Drop for Runnable<M> {
                 (*header).notify(None);
             }
 
-            // Drop the task reference.
-            drop_ref(ptr);
+            drop_runnable::<M>(state, ptr);
         }
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -54,8 +54,8 @@ pub struct Task<T, M = ()> {
     pub(crate) _marker: PhantomData<(T, M)>,
 }
 
-unsafe impl<T: Send, M: Send + Sync> Send for Task<T, M> {}
-unsafe impl<T, M: Send + Sync> Sync for Task<T, M> {}
+unsafe impl<T: Send, M> Send for Task<T, M> {}
+unsafe impl<T, M: Sync> Sync for Task<T, M> {}
 
 impl<T, M> Unpin for Task<T, M> {}
 
@@ -202,7 +202,10 @@ impl<T, M> Task<T, M> {
     ///
     /// Tasks can be created with a metadata object associated with them; by default, this
     /// is a `()` value. See the [`Builder::metadata()`] method for more information.
-    pub fn metadata(&self) -> &M {
+    pub fn metadata(&self) -> &M
+    where
+        M: Sync,
+    {
         let ptr = self.ptr.as_ptr();
         let header = ptr as *const HeaderWithMetadata<M>;
         &unsafe { &*header }.metadata
@@ -273,6 +276,11 @@ fn set_detached<T>(ptr: *const ()) -> Option<Result<T, Panic>> {
                                 if state & CLOSED == 0 {
                                     ((*header).vtable.schedule)(ptr, ScheduleInfo::new(false));
                                 } else {
+                                    // Drop metadata here, since `Task` has been dropped.
+                                    //
+                                    // Safe to call as metadata wouldn't have been
+                                    // dropped before, because we just removed `Task` reference.
+                                    ((*header).vtable.drop_metadata)(ptr);
                                     ((*header).vtable.destroy)(ptr);
                                 }
                             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -54,7 +54,7 @@ pub struct Task<T, M = ()> {
     pub(crate) _marker: PhantomData<(T, M)>,
 }
 
-unsafe impl<T: Send, M> Send for Task<T, M> {}
+unsafe impl<T: Send, M: Send> Send for Task<T, M> {}
 unsafe impl<T, M: Sync> Sync for Task<T, M> {}
 
 impl<T, M> Unpin for Task<T, M> {}


### PR DESCRIPTION
Check #100 for details.

https://github.com/smol-rs/async-task/issues/100#issuecomment-3693112680
https://github.com/smol-rs/async-task/issues/100#issuecomment-3693157650
https://github.com/smol-rs/async-task/issues/100#issuecomment-3696748037

Summary:

Without `M: Send` bound on metadata, we can have unsound behavior. Specifically, as `Waker` is always `Send + Sync`, it can be dropped in any thread and in current implementation, we will drop `M` as well in the thread where we drop last `Waker`.

This PR does following changes:

1. Add `M: 'static` bound on all the safe APIs, we need this because metadata will need to be valid as long as `Runnable` or `Task` is valid.

2. We make sure that we drop `M` (metadata) whenever we have dropped both `Runnable` and `Task`.

3. Add `M: Send` bound for `Builder::spawn`. This is required to avoid unsound behavior described above. We don't need this bound in `Builder::spawn_local` because, we require that `Runnable` be dropped/used on same thread if we use this API. Also `Task: !Send` if `M: !Send`. Therefore, because of change (2) we will never drop `M` on other threads if `M: !Send`.

4. We add `M: Sync` bounds in `.metadata()` API for both `Runnable` and `Task`.

Closes #100 
